### PR TITLE
Add agile filter, sorter for pipeline search api

### DIFF
--- a/pkg/apiserver/query/types.go
+++ b/pkg/apiserver/query/types.go
@@ -81,6 +81,9 @@ func (p *Pagination) GetValidPagination(total int) (startIndex, endIndex int) {
 
 	// no pagination
 	if p.Limit == NoPagination.Limit {
+		if p.Offset >= total {
+			return 0, 0
+		}
 		return 0, total
 	}
 
@@ -121,9 +124,12 @@ func ParseQueryParameter(request *restful.Request) *Query {
 	if err != nil {
 		limit = -1
 	}
+	if limit < -1 {
+		limit = -1
+	}
 	page, err := strconv.Atoi(request.QueryParameter(ParameterPage))
 	// equivalent to undefined, use the default value
-	if err != nil {
+	if err != nil || page < 1 {
 		page = 1
 	}
 

--- a/pkg/apiserver/query/types.go
+++ b/pkg/apiserver/query/types.go
@@ -147,7 +147,14 @@ func ParseQueryParameter(request *restful.Request) *Query {
 	query.LabelSelector = request.QueryParameter(ParameterLabelSelector)
 
 	for key, values := range request.Request.URL.Query() {
-		if !sliceutil.HasString([]string{ParameterPage, ParameterLimit, ParameterOrderBy, ParameterAscending, ParameterLabelSelector}, key) {
+		if !sliceutil.HasString([]string{
+			ParameterPage,
+			ParameterLimit,
+			ParameterOrderBy,
+			ParameterAscending,
+			ParameterLabelSelector,
+			ParameterFieldSelector,
+		}, key) {
 			// support multiple query condition
 			for _, value := range values {
 				query.Filters[Field(key)] = Value(value)

--- a/pkg/apiserver/query/types.go
+++ b/pkg/apiserver/query/types.go
@@ -121,10 +121,7 @@ func ParseQueryParameter(request *restful.Request) *Query {
 
 	limit, err := strconv.Atoi(request.QueryParameter(ParameterLimit))
 	// equivalent to undefined, use the default value
-	if err != nil {
-		limit = -1
-	}
-	if limit < -1 {
+	if err != nil || limit < -1 {
 		limit = -1
 	}
 	page, err := strconv.Atoi(request.QueryParameter(ParameterPage))

--- a/pkg/apiserver/query/types_test.go
+++ b/pkg/apiserver/query/types_test.go
@@ -82,14 +82,6 @@ func TestParseQueryParameter(t *testing.T) {
 }
 
 func TestPagination_GetValidPagination(t *testing.T) {
-	type test struct {
-		name       string
-		limit      int
-		offset     int
-		total      int
-		startIndex int
-		endIndx    int
-	}
 	tests := []struct {
 		name       string
 		limit      int

--- a/pkg/apiserver/query/types_test.go
+++ b/pkg/apiserver/query/types_test.go
@@ -18,6 +18,7 @@ package query
 
 import (
 	"fmt"
+	"github.com/stretchr/testify/assert"
 	"net/http"
 	"testing"
 
@@ -78,4 +79,89 @@ func TestParseQueryParameter(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestPagination_GetValidPagination(t *testing.T) {
+	type test struct {
+		name       string
+		limit      int
+		offset     int
+		total      int
+		startIndex int
+		endIndx    int
+	}
+	tests := []struct {
+		name       string
+		limit      int
+		offset     int
+		total      int
+		startIndex int
+		endIndx    int
+	}{
+		{
+			name:       "Valid pagination 1",
+			limit:      1,
+			offset:     0,
+			total:      1,
+			startIndex: 0,
+			endIndx:    1,
+		},
+		{
+			name:       "Valid pagination 3",
+			limit:      10,
+			offset:     1,
+			total:      20,
+			startIndex: 1,
+			endIndx:    11,
+		},
+		{
+			name:       "Invalid pagination 1",
+			limit:      1,
+			offset:     1,
+			total:      1,
+			startIndex: 1,
+			endIndx:    1,
+		},
+		{
+			name:       "Invalid pagination 2",
+			limit:      10,
+			offset:     10,
+			total:      10,
+			startIndex: 10,
+			endIndx:    10,
+		},
+		{
+			name:       "Unlimited: Offset = 0",
+			limit:      -1,
+			offset:     0,
+			total:      1000,
+			startIndex: 0,
+			endIndx:    1000,
+		},
+		{
+			name:       "Unlimited: Offset > 0",
+			limit:      -1,
+			offset:     10,
+			total:      5,
+			startIndex: 0,
+			endIndx:    0,
+		},
+		{
+			name:       "Unlimited: Offset > total",
+			limit:      -1,
+			offset:     10,
+			total:      5,
+			startIndex: 0,
+			endIndx:    0,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			pagination := newPagination(test.limit, test.offset)
+			startIndex, endIndex := pagination.GetValidPagination(test.total)
+			assert.Equal(t, test.startIndex, startIndex)
+			assert.Equal(t, test.endIndx, endIndex)
+		})
+	}
+
 }

--- a/pkg/kapis/devops/v1alpha2/devops.go
+++ b/pkg/kapis/devops/v1alpha2/devops.go
@@ -114,7 +114,7 @@ func (h *ProjectPipelineHandler) ListPipelines(req *restful.Request, resp *restf
 	}
 	pipelineMap := make(map[string]int, pipelineList.Total)
 	for i, _ := range objs.Items {
-		if pipeline, ok := objs.Items[i].(v1alpha3.Pipeline); !ok {
+		if pipeline, ok := objs.Items[i].(*v1alpha3.Pipeline); !ok {
 			continue
 		} else {
 			pipelineMap[pipeline.Name] = i

--- a/pkg/kapis/devops/v1alpha2/devops.go
+++ b/pkg/kapis/devops/v1alpha2/devops.go
@@ -71,14 +71,27 @@ func (h *ProjectPipelineHandler) getPipelinesByRequest(req *restful.Request) (ap
 
 	// for filter compatibility
 	if _, ok := queryParam.Filters[query.FieldName]; !ok {
-		// if name query is not set
+		// set name filter by default
 		queryParam.Filters[query.FieldName] = query.Value(pipelineName)
 	}
 
+	// for compare compatibility
+	if len(req.QueryParameter(query.ParameterOrderBy)) == 0 {
+		// set sort by as name by default
+		queryParam.SortBy = query.FieldName
+	}
+
+	// for ascending compatibility
+	if len(req.QueryParameter(query.ParameterAscending)) == 0 {
+		// set ascending as true by default
+		queryParam.Ascending = true
+	}
+
 	// make sure we have an appropriate value
-	return h.devopsOperator.ListPipelineObj(namespace, nil, func(list []v1alpha3.Pipeline, i int, j int) bool {
-		return strings.Compare(strings.ToUpper(list[i].Name), strings.ToUpper(list[j].Name)) < 0
-	}, queryParam)
+	return h.devopsOperator.ListPipelineObj(namespace,
+		nil,
+		nil,
+		queryParam)
 }
 
 func parseNameFilterFromQuery(query string) (pipelineName, namespace string) {

--- a/pkg/kapis/devops/v1alpha2/devops.go
+++ b/pkg/kapis/devops/v1alpha2/devops.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"kubesphere.io/devops/pkg/apiserver/query"
 	"net/http"
 	"strings"
 
@@ -37,7 +38,6 @@ import (
 	//"kubesphere.io/devops/pkg/apiserver/request"
 	"kubesphere.io/devops/pkg/constants"
 	"kubesphere.io/devops/pkg/models/devops"
-	"kubesphere.io/devops/pkg/server/params"
 )
 
 const jenkinsHeaderPre = "X-"
@@ -58,20 +58,17 @@ func (h *ProjectPipelineHandler) GetPipeline(req *restful.Request, resp *restful
 
 func (h *ProjectPipelineHandler) getPipelinesByRequest(req *restful.Request) (api.ListResult, error) {
 	// this is a very trick way, but don't have a better solution for now
-	var (
-		start     int
-		limit     int
-		namespace string
-	)
+	var namespace string
 
 	// parse query from the request
 	pipelineFilter, namespace := parseNameFilterFromQuery(req.QueryParameter("q"))
 
+	queryParam := query.ParseQueryParameter(req)
+
 	// make sure we have an appropriate value
-	limit, start = params.ParsePaging(req)
 	return h.devopsOperator.ListPipelineObj(namespace, pipelineFilter, func(list []v1alpha3.Pipeline, i int, j int) bool {
 		return strings.Compare(strings.ToUpper(list[i].Name), strings.ToUpper(list[j].Name)) < 0
-	}, limit, start)
+	}, queryParam)
 }
 
 func parseNameFilterFromQuery(query string) (filter devops.PipelineFilter, namespace string) {

--- a/pkg/kapis/devops/v1alpha2/devops.go
+++ b/pkg/kapis/devops/v1alpha2/devops.go
@@ -88,10 +88,7 @@ func (h *ProjectPipelineHandler) getPipelinesByRequest(req *restful.Request) (ap
 	}
 
 	// make sure we have an appropriate value
-	return h.devopsOperator.ListPipelineObj(namespace,
-		nil,
-		nil,
-		queryParam)
+	return h.devopsOperator.ListPipelineObj(namespace, queryParam)
 }
 
 func parseNameFilterFromQuery(query string) (pipelineName, namespace string) {

--- a/pkg/kapis/devops/v1alpha2/devops_test.go
+++ b/pkg/kapis/devops/v1alpha2/devops_test.go
@@ -40,13 +40,11 @@ func TestParseNameFilterFromQuery(t *testing.T) {
 		message:              "query all pipelines with filter *",
 	}}
 
-	for i, item := range table {
+	for _, item := range table {
 		t.Run(item.message, func(t *testing.T) {
 			pipelineName, ns := parseNameFilterFromQuery(item.query)
 			assert.Equal(t, item.expectedPipelineName, pipelineName)
-			if ns != item.expectNamespace {
-				t.Fatalf("invalid namespace, index: %d, message: %s", i, item.message)
-			}
+			assert.Equal(t, item.expectNamespace, ns)
 		})
 	}
 }

--- a/pkg/kapis/devops/v1alpha2/devops_test.go
+++ b/pkg/kapis/devops/v1alpha2/devops_test.go
@@ -1,62 +1,52 @@
 package v1alpha2
 
 import (
-	"strings"
+	"github.com/stretchr/testify/assert"
 	"testing"
 
 	"kubesphere.io/devops/pkg/api/devops/v1alpha3"
-
-	"kubesphere.io/devops/pkg/models/devops"
 )
 
 func TestParseNameFilterFromQuery(t *testing.T) {
 	table := []struct {
-		query           string
-		pipeline        *v1alpha3.Pipeline
-		expectFilter    devops.PipelineFilter
-		expectNamespace string
-		message         string
+		query                string
+		pipeline             *v1alpha3.Pipeline
+		expectNamespace      string
+		expectedPipelineName string
+		message              string
 	}{{
-		query:           "type:pipeline;organization:jenkins;pipeline:serverjkq4c/*",
-		pipeline:        &v1alpha3.Pipeline{},
-		expectFilter:    nil,
-		expectNamespace: "serverjkq4c",
-		message:         "query all pipelines with filter *",
+		query:                "type:pipeline;organization:jenkins;pipeline:serverjkq4c/*",
+		pipeline:             &v1alpha3.Pipeline{},
+		expectNamespace:      "serverjkq4c",
+		expectedPipelineName: "",
+		message:              "query all pipelines with filter *",
 	}, {
-		query:    "type:pipeline;organization:jenkins;pipeline:cccc/*abc*",
-		pipeline: &v1alpha3.Pipeline{},
-		expectFilter: func(pipeline *v1alpha3.Pipeline) bool {
-			return strings.Contains(pipeline.Name, "abc")
-		},
-		expectNamespace: "cccc",
-		message:         "query all pipelines with filter abc",
+		query:                "type:pipeline;organization:jenkins;pipeline:cccc/*abc*",
+		pipeline:             &v1alpha3.Pipeline{},
+		expectNamespace:      "cccc",
+		expectedPipelineName: "abc",
+		message:              "query all pipelines with filter abc",
 	}, {
-		query:           "type:pipeline;organization:jenkins;pipeline:pai-serverjkq4c/*",
-		pipeline:        &v1alpha3.Pipeline{},
-		expectFilter:    nil,
-		expectNamespace: "pai-serverjkq4c",
-		message:         "query all pipelines with filter *",
+		query:                "type:pipeline;organization:jenkins;pipeline:pai-serverjkq4c/*",
+		pipeline:             &v1alpha3.Pipeline{},
+		expectNamespace:      "pai-serverjkq4c",
+		expectedPipelineName: "",
+		message:              "query all pipelines with filter *",
 	}, {
-		query:           "type:pipeline;organization:jenkins;pipeline:defdef",
-		pipeline:        &v1alpha3.Pipeline{},
-		expectFilter:    nil,
-		expectNamespace: "defdef",
-		message:         "query all pipelines with filter *",
+		query:                "type:pipeline;organization:jenkins;pipeline:defdef",
+		pipeline:             &v1alpha3.Pipeline{},
+		expectNamespace:      "defdef",
+		expectedPipelineName: "",
+		message:              "query all pipelines with filter *",
 	}}
 
 	for i, item := range table {
-		filter, ns := parseNameFilterFromQuery(item.query)
-		if item.expectFilter == nil {
-			if filter != nil {
-				t.Fatalf("invalid filter, index: %d, message: %s", i, item.message)
+		t.Run(item.message, func(t *testing.T) {
+			pipelineName, ns := parseNameFilterFromQuery(item.query)
+			assert.Equal(t, item.expectedPipelineName, pipelineName)
+			if ns != item.expectNamespace {
+				t.Fatalf("invalid namespace, index: %d, message: %s", i, item.message)
 			}
-		} else {
-			if filter == nil || filter(item.pipeline) != item.expectFilter(item.pipeline) {
-				t.Fatalf("invalid filter, index: %d, message: %s", i, item.message)
-			}
-		}
-		if ns != item.expectNamespace {
-			t.Fatalf("invalid namespace, index: %d, message: %s", i, item.message)
-		}
+		})
 	}
 }

--- a/pkg/kapis/devops/v1alpha2/handler.go
+++ b/pkg/kapis/devops/v1alpha2/handler.go
@@ -39,7 +39,7 @@ type PipelineSonarHandler struct {
 
 func NewProjectPipelineHandler(devopsClient devopsClient.Interface, k8sClient k8s.Client) ProjectPipelineHandler {
 	return ProjectPipelineHandler{
-		devopsOperator:          devops.NewDevopsOperator(devopsClient, nil, nil),
+		devopsOperator:          devops.NewDevopsOperator(devopsClient, k8sClient.Kubernetes(), k8sClient.KubeSphere()),
 		projectCredentialGetter: devops.NewProjectCredentialOperator(devopsClient),
 		k8sClient:               k8sClient,
 	}

--- a/pkg/kapis/devops/v1alpha3/handler.go
+++ b/pkg/kapis/devops/v1alpha3/handler.go
@@ -196,7 +196,7 @@ func (h *devopsHandler) ListPipeline(request *restful.Request, response *restful
 	queryParam := query.ParseQueryParameter(request)
 
 	if client, err := h.getDevOps(request); err == nil {
-		objs, err := client.ListPipelineObj(devopsProject, nil, nil, queryParam)
+		objs, err := client.ListPipelineObj(devopsProject, queryParam)
 		if err != nil {
 			klog.Error(err)
 			if errors.IsNotFound(err) {

--- a/pkg/kapis/devops/v1alpha3/handler.go
+++ b/pkg/kapis/devops/v1alpha3/handler.go
@@ -193,10 +193,10 @@ func (h *devopsHandler) GetPipeline(request *restful.Request, response *restful.
 
 func (h *devopsHandler) ListPipeline(request *restful.Request, response *restful.Response) {
 	devopsProject := request.PathParameter("devops")
-	limit, offset := params.ParsePaging(request)
+	queryParam := query.ParseQueryParameter(request)
 
 	if client, err := h.getDevOps(request); err == nil {
-		objs, err := client.ListPipelineObj(devopsProject, nil, nil, limit, offset)
+		objs, err := client.ListPipelineObj(devopsProject, nil, nil, queryParam)
 		if err != nil {
 			klog.Error(err)
 			if errors.IsNotFound(err) {

--- a/pkg/models/devops/devops.go
+++ b/pkg/models/devops/devops.go
@@ -49,9 +49,6 @@ const (
 	channelMaxCapacity = 100
 )
 
-type PipelineFilter func(pipeline *v1alpha3.Pipeline) bool
-type PipelineSorter func([]v1alpha3.Pipeline, int, int) bool
-
 type DevopsOperator interface {
 	CreateDevOpsProject(workspace string, project *v1alpha3.DevOpsProject) (*v1alpha3.DevOpsProject, error)
 	GetDevOpsProject(workspace string, projectName string) (*v1alpha3.DevOpsProject, error)
@@ -63,7 +60,7 @@ type DevopsOperator interface {
 	GetPipelineObj(projectName string, pipelineName string) (*v1alpha3.Pipeline, error)
 	DeletePipelineObj(projectName string, pipelineName string) error
 	UpdatePipelineObj(projectName string, pipeline *v1alpha3.Pipeline) (*v1alpha3.Pipeline, error)
-	ListPipelineObj(projectName string, filterFunc PipelineFilter, sortFunc PipelineSorter, query *query.Query) (api.ListResult, error)
+	ListPipelineObj(projectName string, query *query.Query) (api.ListResult, error)
 
 	CreateCredentialObj(projectName string, s *v1.Secret) (*v1.Secret, error)
 	GetCredentialObj(projectName string, secretName string) (*v1.Secret, error)
@@ -265,7 +262,7 @@ func (d devopsOperator) UpdatePipelineObj(projectName string, pipeline *v1alpha3
 	return d.ksclient.DevopsV1alpha3().Pipelines(ns).Update(d.context, pipeline, metav1.UpdateOptions{})
 }
 
-func (d devopsOperator) ListPipelineObj(projectName string, filterFunc PipelineFilter, sortFunc PipelineSorter, query *query.Query) (api.ListResult, error) {
+func (d devopsOperator) ListPipelineObj(projectName string, query *query.Query) (api.ListResult, error) {
 	project, err := d.ksclient.DevopsV1alpha3().DevOpsProjects().Get(d.context, projectName, metav1.GetOptions{})
 	if err != nil {
 		return api.ListResult{}, err

--- a/pkg/models/devops/devops.go
+++ b/pkg/models/devops/devops.go
@@ -282,25 +282,6 @@ func (d devopsOperator) ListPipelineObj(projectName string, filterFunc PipelineF
 	for i, _ := range pipelines.Items {
 		result = append(result, &pipelines.Items[i])
 	}
-	//if sortFunc != nil {
-	//	//sort the pipeline list according to the request
-	//	sort.SliceStable(data, func(i, j int) bool {
-	//		return sortFunc(data, i, j)
-	//	})
-	//}
-	//
-	//var result = make([]runtime.Object, 0)
-	//for i := range data {
-	//	if filterFunc != nil && !filterFunc(&data[i]) {
-	//		continue
-	//	}
-	//	result = append(result, &data[i])
-	//}
-	//
-	//var items = make([]runtime.Object, 0)
-	//
-	//startIndex, endIndex := query.Pagination.GetValidPagination(len(result))
-	//items = result[startIndex:endIndex]
 
 	return *resourcesV1alpha3.DefaultList(result, query, d.compare, d.filter), nil
 }

--- a/pkg/models/devops/devops.go
+++ b/pkg/models/devops/devops.go
@@ -24,7 +24,6 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
-	"sort"
 	"strings"
 	"sync"
 
@@ -279,33 +278,31 @@ func (d devopsOperator) ListPipelineObj(projectName string, filterFunc PipelineF
 		return api.ListResult{}, err
 	}
 
-	data := pipelines.Items
-	if sortFunc != nil {
-		//sort the pipeline list according to the request
-		sort.SliceStable(data, func(i, j int) bool {
-			return sortFunc(data, i, j)
-		})
+	var result = make([]runtime.Object, len(pipelines.Items))
+	for i, _ := range pipelines.Items {
+		result = append(result, &pipelines.Items[i])
 	}
+	//if sortFunc != nil {
+	//	//sort the pipeline list according to the request
+	//	sort.SliceStable(data, func(i, j int) bool {
+	//		return sortFunc(data, i, j)
+	//	})
+	//}
+	//
+	//var result = make([]runtime.Object, 0)
+	//for i := range data {
+	//	if filterFunc != nil && !filterFunc(&data[i]) {
+	//		continue
+	//	}
+	//	result = append(result, &data[i])
+	//}
+	//
+	//var items = make([]runtime.Object, 0)
+	//
+	//startIndex, endIndex := query.Pagination.GetValidPagination(len(result))
+	//items = result[startIndex:endIndex]
 
-	var result = make([]runtime.Object, 0)
-	for i := range data {
-		if filterFunc != nil && !filterFunc(&data[i]) {
-			continue
-		}
-		result = append(result, &data[i])
-	}
-
-	var (
-		limit  = query.Pagination.Limit
-		offset = query.Pagination.Offset
-	)
-
-	if limit == -1 || limit+offset > len(result) {
-		limit = len(result) - offset
-	}
-	items := result[offset : offset+limit]
-
-	return *resourcesV1alpha3.DefaultList(items, query, d.compare, d.filter), nil
+	return *resourcesV1alpha3.DefaultList(result, query, d.compare, d.filter), nil
 }
 
 //credentialobj in crd

--- a/pkg/models/resources/v1alpha3/interface.go
+++ b/pkg/models/resources/v1alpha3/interface.go
@@ -122,14 +122,14 @@ func DefaultObjectMetaFilter(item metav1.ObjectMeta, filter query.Filter) bool {
 		return strings.Contains(item.Name, string(filter.Value))
 		// /namespaces?page=1&limit=10&uid=a8a8d6cf-f6a5-4fea-9c1b-e57610115706
 	case query.FieldUID:
-		return strings.Compare(string(item.UID), string(filter.Value)) == 0
+		return string(item.UID) == string(filter.Value)
 		// /deployments?page=1&limit=10&namespace=kubesphere-system
 	case query.FieldNamespace:
-		return strings.Compare(item.Namespace, string(filter.Value)) == 0
+		return item.Namespace == string(filter.Value)
 		// /namespaces?page=1&limit=10&ownerReference=a8a8d6cf-f6a5-4fea-9c1b-e57610115706
 	case query.FieldOwnerReference:
 		for _, ownerReference := range item.OwnerReferences {
-			if strings.Compare(string(ownerReference.UID), string(filter.Value)) == 0 {
+			if string(ownerReference.UID) == string(filter.Value) {
 				return true
 			}
 		}
@@ -137,7 +137,7 @@ func DefaultObjectMetaFilter(item metav1.ObjectMeta, filter query.Filter) bool {
 		// /namespaces?page=1&limit=10&ownerKind=Workspace
 	case query.FieldOwnerKind:
 		for _, ownerReference := range item.OwnerReferences {
-			if strings.Compare(ownerReference.Kind, string(filter.Value)) == 0 {
+			if ownerReference.Kind == string(filter.Value) {
 				return true
 			}
 		}

--- a/pkg/models/resources/v1alpha3/interface.go
+++ b/pkg/models/resources/v1alpha3/interface.go
@@ -93,11 +93,10 @@ func DefaultObjectMetaCompare(left, right metav1.ObjectMeta, sortBy query.Field)
 	switch sortBy {
 	// ?sortBy=name
 	case query.FieldName:
+		// sort the name in ascending order
 		return strings.Compare(left.Name, right.Name) > 0
 	//	?sortBy=creationTimestamp
 	default:
-		fallthrough
-	case query.FieldCreateTime:
 		fallthrough
 	case query.FieldCreationTimeStamp:
 		// compare by name if creation timestamp is equal
@@ -108,7 +107,7 @@ func DefaultObjectMetaCompare(left, right metav1.ObjectMeta, sortBy query.Field)
 	}
 }
 
-//  Default metadata filter
+// DefaultObjectMetaFilter filters data with given filter
 func DefaultObjectMetaFilter(item metav1.ObjectMeta, filter query.Filter) bool {
 	switch filter.Field {
 	case query.FieldNames:
@@ -155,11 +154,12 @@ func DefaultObjectMetaFilter(item metav1.ObjectMeta, filter query.Filter) bool {
 	}
 }
 
+// labelsMatch handles multi label value pair split by ","
 func labelsMatch(labels map[string]string, filterStr string) bool {
 	filters := strings.SplitN(filterStr, ",", 2)
 	var match = true
 	for _, filter := range filters {
-		match = match && labelMatch(labels, filter)
+		match = match && labelMatch(labels, strings.TrimSpace(filter))
 	}
 	return match
 }

--- a/pkg/models/resources/v1alpha3/interface.go
+++ b/pkg/models/resources/v1alpha3/interface.go
@@ -154,12 +154,16 @@ func DefaultObjectMetaFilter(item metav1.ObjectMeta, filter query.Filter) bool {
 	}
 }
 
-// labelsMatch handles multi label value pair split by ","
+// labelsMatch handles multi-label value pairs split by ",".
+// e.g. devops.ks.io/creator=admin,devops.ks.io/status=success
 func labelsMatch(labels map[string]string, filterStr string) bool {
-	filters := strings.SplitN(filterStr, ",", 2)
+	filters := strings.Split(filterStr, ",")
 	var match = true
 	for _, filter := range filters {
 		match = match && labelMatch(labels, strings.TrimSpace(filter))
+		if !match {
+			break
+		}
 	}
 	return match
 }

--- a/pkg/models/resources/v1alpha3/interface_test.go
+++ b/pkg/models/resources/v1alpha3/interface_test.go
@@ -245,11 +245,11 @@ func TestDefaultObjectMetaCompare(t *testing.T) {
 
 func TestDefaultList(t *testing.T) {
 	objectMetaFilterFunc := func(object runtime.Object, filter query.Filter) bool {
-		if pipeline, ok := object.(*v1alpha3.Pipeline); !ok {
+		pipeline, ok := object.(*v1alpha3.Pipeline)
+		if !ok {
 			return false
-		} else {
-			return DefaultObjectMetaFilter(pipeline.ObjectMeta, filter)
 		}
+		return DefaultObjectMetaFilter(pipeline.ObjectMeta, filter)
 	}
 	objectMetaCompareFunc := func(leftObj runtime.Object, rightObj runtime.Object, field query.Field) bool {
 		leftPipeline, ok := leftObj.(*v1alpha3.Pipeline)

--- a/pkg/models/resources/v1alpha3/interface_test.go
+++ b/pkg/models/resources/v1alpha3/interface_test.go
@@ -18,7 +18,13 @@
 
 package v1alpha3
 
-import "testing"
+import (
+	"gotest.tools/assert"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"kubesphere.io/devops/pkg/apiserver/query"
+	"testing"
+	"time"
+)
 
 func TestLabelMatch(t *testing.T) {
 	tests := []struct {
@@ -81,5 +87,155 @@ func TestLabelMatch(t *testing.T) {
 		if result != test.expectResult {
 			t.Errorf("case %d, got %#v, expected %#v", i, result, test.expectResult)
 		}
+	}
+}
+
+func TestLabelsMatch(t *testing.T) {
+	table := []struct {
+		name          string
+		labels        map[string]string
+		filter        string
+		expectedMatch bool
+	}{{
+		name: "fully match(single)",
+		labels: map[string]string{
+			"kubesphere.io/creator": "admin",
+		},
+		filter:        "kubesphere.io/creator=admin",
+		expectedMatch: true,
+	}, {
+		name: "fully mismatch(single)",
+		labels: map[string]string{
+			"kubesphere.io/creator": "admin",
+		},
+		filter:        "kubesphere.io/creator=tester",
+		expectedMatch: false,
+	}, {
+		name: "fully match(multi)",
+		labels: map[string]string{
+			"kubesphere.io/creator": "admin",
+			"kubesphere.io/status":  "success",
+		},
+		filter:        "kubesphere.io/creator=admin,kubesphere.io/status=success",
+		expectedMatch: true,
+	}, {
+		name: "partial match(multi)",
+		labels: map[string]string{
+			"kubesphere.io/creator": "admin",
+			"kubesphere.io/status":  "success",
+		},
+		filter:        "kubesphere.io/creator=tester,kubesphere.io/status=success",
+		expectedMatch: false,
+	}, {
+		name: "fully mismatch(multi)",
+		labels: map[string]string{
+			"kubesphere.io/creator": "admin",
+			"kubesphere.io/status":  "success",
+		},
+		filter:        "kubesphere.io/creator=tester,kubesphere.io/status=fail",
+		expectedMatch: false,
+	}, {
+		name:          "empty labels",
+		labels:        map[string]string{},
+		filter:        "kubesphere.io/creator=admin",
+		expectedMatch: false,
+	},
+	}
+	for _, item := range table {
+		t.Run(item.name, func(t *testing.T) {
+			match := labelsMatch(item.labels, item.filter)
+			assert.Equal(t, item.expectedMatch, match)
+		})
+	}
+}
+
+func TestDefaultObjectMetaCompare(t *testing.T) {
+	now := v1.Now()
+	tables := []struct {
+		name              string
+		left              v1.ObjectMeta
+		right             v1.ObjectMeta
+		field             query.Field
+		expectedCmpResult bool
+	}{{
+		name: "compare name with descending order",
+		left: v1.ObjectMeta{
+			Name: "b",
+		},
+		right: v1.ObjectMeta{
+			Name: "a",
+		},
+		field:             query.FieldName,
+		expectedCmpResult: true,
+	}, {
+		name: "compare same name",
+		left: v1.ObjectMeta{
+			Name: "a",
+		},
+		right: v1.ObjectMeta{
+			Name: "a",
+		},
+		field:             query.FieldName,
+		expectedCmpResult: false,
+	}, {
+		name: "compare name with ascending order",
+		left: v1.ObjectMeta{
+			Name: "a",
+		},
+		right: v1.ObjectMeta{
+			Name: "b",
+		},
+		field:             query.FieldName,
+		expectedCmpResult: false,
+	}, {
+		name: "compare same creation timestamp",
+		left: v1.ObjectMeta{
+			Name:              "a",
+			CreationTimestamp: now,
+		},
+		right: v1.ObjectMeta{
+			Name:              "b",
+			CreationTimestamp: now,
+		},
+		field:             query.FieldCreationTimeStamp,
+		expectedCmpResult: false,
+	}, {
+		name: "compare creation timestamp with descending order",
+		left: v1.ObjectMeta{
+			CreationTimestamp: now,
+		},
+		right: v1.ObjectMeta{
+			CreationTimestamp: v1.NewTime(now.Truncate(time.Second)),
+		},
+		field:             query.FieldCreationTimeStamp,
+		expectedCmpResult: true,
+	}, {
+		name: "compare creation timestamp with ascending order",
+		left: v1.ObjectMeta{
+			CreationTimestamp: now,
+		},
+		right: v1.ObjectMeta{
+			CreationTimestamp: v1.NewTime(now.Add(time.Second)),
+		},
+		field:             query.FieldCreationTimeStamp,
+		expectedCmpResult: false,
+	}, {
+		name: "compare others",
+		left: v1.ObjectMeta{
+			CreationTimestamp: now,
+		},
+		right: v1.ObjectMeta{
+			CreationTimestamp: v1.NewTime(now.Add(time.Second)),
+		},
+		field:             query.FieldUID,
+		expectedCmpResult: false,
+	},
+	}
+
+	for _, item := range tables {
+		t.Run(item.name, func(t *testing.T) {
+			result := DefaultObjectMetaCompare(item.left, item.right, item.field)
+			assert.Equal(t, item.expectedCmpResult, result)
+		})
 	}
 }

--- a/pkg/models/resources/v1alpha3/interface_test.go
+++ b/pkg/models/resources/v1alpha3/interface_test.go
@@ -118,8 +118,9 @@ func TestLabelsMatch(t *testing.T) {
 		labels: map[string]string{
 			"kubesphere.io/creator": "admin",
 			"kubesphere.io/status":  "success",
+			"kubesphere.io/synced":  "true",
 		},
-		filter:        "kubesphere.io/creator=admin,kubesphere.io/status=success",
+		filter:        "kubesphere.io/creator=admin,kubesphere.io/status=success,kubesphere.io/synced=true",
 		expectedMatch: true,
 	}, {
 		name: "partial match(multi)",

--- a/pkg/server/params/params.go
+++ b/pkg/server/params/params.go
@@ -42,7 +42,7 @@ const (
 // supported format: ?paging=limit=100,page=1
 func ParsePaging(req *restful.Request) (limit, offset int) {
 	paging := req.QueryParameter(PagingParam)
-	limit = 10
+	limit = DefaultLimit
 	page := DefaultPage
 	if paging != "" {
 		if groups := regexp.MustCompile(`^limit=(-?\d+),page=(\d+)$`).FindStringSubmatch(paging); len(groups) == 3 {


### PR DESCRIPTION

### What this pr is for:

This PR is trying to provide more agile filter, sorter for pipeline search api. If do that, we can add more

### What this PR dose:

1. Remove `PipelineFilter` and `PipelineSorter`
2. Use more generic `FilterFunc` and `CompareFunc` instead
3. Add some tests on new mechanism
4. Compatible with previous way of searching pipeline

### What is new:

I've provide more generic way to add filters and sorter for pipeline search api. And I'm going to explain this feature.

Now, we support the following parameters for query:

> See more about [Kubernetes ObjectMeta](https://github.com/kubernetes/apimachinery/blob/a644435e2c133d990b624858d9c01985d7f59adf/pkg/apis/meta/v1/types.go#L116)

- Filters

| Parameter name | Description                         | Filter(contains, match pattern, is)                                             | Example                                                              |
| -------------- | ----------------------------------- | ------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
| name           | object name                         | contains, case sensitive                                                        | /pipeline?name=pipeline1                                             |
| names          | object names, separated by ","      | is                                                                              | /pipeline?name=pipeline1,pipelin2                                    |
| uid            | object unique id                    | is                                                                              | /pipelins?uid=abcdefg-hijklmn                                        |
| namespace      | object namespace                    | is                                                                              | /pipelines?namespace=default                                         |
| ownerReference | object owner reference id           | is                                                                              | /pipelines?ownerReference=abcdefg-hijk                               |
| ownerKind      | object owner kind name              | is                                                                              | /pipelines?ownerKind=devopsproject                                   |
| annotation     | object annotation, separated by "," | is                                                                              | /pipelines?annotation=pipeline/creator=admin,pipeline/status=success |
| label          | object label, seprated by ","       | is                                                                              | /pipelines?label=app=pipeline,multibranch=true                       |
| labelSelector  | object label selector               | [more details](https://pkg.go.dev/k8s.io/apimachinery@v0.21.3/pkg/labels#Parse) | /pipelines?labelSelector=x in (foo,,baz),y,z notin ()                |

- Sorter

We have provide two parameters to build a sorter: `sortBy` and `ascending`(default is false).

| Name of sorter    | Description               | Example                                             |
| ----------------- | ------------------------- | --------------------------------------------------- |
| name              | object name               | /pipelines?sortBy=name&ascending=true               |
| creationTimestamp | object creation timestamp | /pipelines?sortBy=creationTimestamp&ascending=false |

### Which issue(s) this PR fixes:

Also fix https://github.com/kubesphere/kubesphere/issues/3959

### Special notes for reviewers:

API test is not easily to be created programmatically now, so the tests won't focus on API but underlying function the API relies on. BWT, I've tested API functionality by my hand.
