### PR TITLE
Fix the container namespace from linuxsuren to kubesphere-sigs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,11 +19,11 @@ jobs:
       - uses: actions/checkout@v2
       - name: Docker meta for kubesphere
         id: meta
-        if: github.repository_owner == 'kubesphere'
+        if: github.repository_owner == 'kubesphere-sigs'
         uses: docker/metadata-action@v3
         with:
           images: |
-            kubespheredev/devops-controller
+            kubespheresig/devops-controller
             ghcr.io/${{ github.repository_owner }}/devops-controller
           tags: |
             type=schedule
@@ -33,7 +33,7 @@ jobs:
             type=sha
       - name: Docker meta for Contributors
         id: metaContributors
-        if: github.repository_owner != 'kubesphere'
+        if: github.repository_owner != 'kubesphere-sigs'
         uses: docker/metadata-action@v3
         with:
           images: |
@@ -63,7 +63,7 @@ jobs:
           password: ${{ secrets.GHCR_TOKEN }}
       - name: Build and push Docker images
         uses: docker/build-push-action@v2.4.0
-        if: github.repository_owner == 'kubesphere'
+        if: github.repository_owner == 'kubesphere-sigs'
         with:
           file: config/dockerfiles/controller-manager/Dockerfile
           tags: ${{ steps.meta.outputs.tags }}
@@ -72,7 +72,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
       - name: Build and push Docker images for Contributors
         uses: docker/build-push-action@v2.4.0
-        if: github.repository_owner != 'kubesphere'
+        if: github.repository_owner != 'kubesphere-sigs'
         with:
           file: config/dockerfiles/controller-manager/Dockerfile
           tags: ${{ steps.metaContributors.outputs.tags }}
@@ -86,11 +86,11 @@ jobs:
       - uses: actions/checkout@v2
       - name: Docker meta for kubesphere
         id: meta
-        if: github.repository_owner == 'kubesphere'
+        if: github.repository_owner == 'kubesphere-sigs'
         uses: docker/metadata-action@v3
         with:
           images: |
-            kubespheredev/devops-apiserver
+            kubespheresig/devops-apiserver
             ghcr.io/${{ github.repository_owner }}/devops-apiserver
           tags: |
             type=schedule
@@ -100,7 +100,7 @@ jobs:
             type=sha
       - name: Docker meta for Contributors
         id: metaContributors
-        if: github.repository_owner != 'kubesphere'
+        if: github.repository_owner != 'kubesphere-sigs'
         uses: docker/metadata-action@v3
         with:
           images: |
@@ -130,7 +130,7 @@ jobs:
           password: ${{ secrets.GHCR_TOKEN }}
       - name: Build and push Docker images
         uses: docker/build-push-action@v2.4.0
-        if: github.repository_owner == 'kubesphere'
+        if: github.repository_owner == 'kubesphere-sigs'
         with:
           file: config/dockerfiles/apiserver/Dockerfile
           tags: ${{ steps.meta.outputs.tags }}
@@ -139,7 +139,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
       - name: Build and push Docker images for Contributors
         uses: docker/build-push-action@v2.4.0
-        if: github.repository_owner != 'kubesphere'
+        if: github.repository_owner != 'kubesphere-sigs'
         with:
           file: config/dockerfiles/apiserver/Dockerfile
           tags: ${{ steps.metaContributors.outputs.tags }}
@@ -153,11 +153,11 @@ jobs:
       - uses: actions/checkout@v2
       - name: Docker meta for kubesphere
         id: meta
-        if: github.repository_owner == 'kubesphere'
+        if: github.repository_owner == 'kubesphere-sigs'
         uses: docker/metadata-action@v3
         with:
           images: |
-            kubespheredev/devops-tools
+            kubespheresig/devops-tools
             ghcr.io/${{ github.repository_owner }}/devops-tools
           tags: |
             type=schedule
@@ -167,7 +167,7 @@ jobs:
             type=sha
       - name: Docker meta for Contributors
         id: metaContributors
-        if: github.repository_owner != 'kubesphere'
+        if: github.repository_owner != 'kubesphere-sigs'
         uses: docker/metadata-action@v3
         with:
           images: |
@@ -197,7 +197,7 @@ jobs:
           password: ${{ secrets.GHCR_TOKEN }}
       - name: Build and push Docker images
         uses: docker/build-push-action@v2.4.0
-        if: github.repository_owner == 'kubesphere'
+        if: github.repository_owner == 'kubesphere-sigs'
         with:
           file: config/dockerfiles/tools/Dockerfile
           tags: ${{ steps.meta.outputs.tags }}
@@ -206,7 +206,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
       - name: Build and push Docker images for Contributors
         uses: docker/build-push-action@v2.4.0
-        if: github.repository_owner != 'kubesphere'
+        if: github.repository_owner != 'kubesphere-sigs'
         with:
           file: config/dockerfiles/tools/Dockerfile
           tags: ${{ steps.metaContributors.outputs.tags }}

--- a/README.md
+++ b/README.md
@@ -98,12 +98,8 @@ It provides a dashboard for Kubernetes and ks-devops.
 
 ## Available communication channels:
 
-- [kubesphere Devops google group ](https://groups.google.com/g/kubesphere-sig-devops/)
-    
+- [KubeSphere Devops google group](https://groups.google.com/g/kubesphere-sig-devops/)
 - [DevOps Slack channel for English speakers](https://kubesphere.slack.com/archives/C010TH02010)
-    
 - [DevOps Slack channel for Chinese speakers](https://kubesphere.slack.com/archives/C026V4FBWBW)
-    
 - [Forum for Chinese speakers](https://kubesphere.com.cn/forum/t/DevOps)
-    
 - [KubeSphere DevOps Special Interest Group](https://github.com/kubesphere/community/tree/master/sig-devops)

--- a/README.md
+++ b/README.md
@@ -95,3 +95,15 @@ It provides a dashboard for Kubernetes and ks-devops.
 
 ## License
 [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2FLinuxSuRen%2Fks-devops.svg?type=large)](https://app.fossa.com/projects/git%2Bgithub.com%2FLinuxSuRen%2Fks-devops?ref=badge_large)
+
+## Available communication channels:
+
+- [kubesphere Devops google group ](https://groups.google.com/g/kubesphere-sig-devops/)
+    
+- [DevOps Slack channel for English speakers](https://kubesphere.slack.com/archives/C010TH02010)
+    
+- [DevOps Slack channel for Chinese speakers](https://kubesphere.slack.com/archives/C026V4FBWBW)
+    
+- [Forum for Chinese speakers](https://kubesphere.com.cn/forum/t/DevOps)
+    
+- [KubeSphere DevOps Special Interest Group](https://github.com/kubesphere/community/tree/master/sig-devops)

--- a/charts/ks-devops/values.yaml
+++ b/charts/ks-devops/values.yaml
@@ -2,13 +2,13 @@ replicaCount: 1
 
 image:
   controller:
-    repository: ghcr.io/linuxsuren/devops-controller
+    repository: ghcr.io/kubesphere-sigs/devops-controller
     tag: master
   apiserver:
-    repository: ghcr.io/linuxsuren/devops-apiserver
+    repository: ghcr.io/kubesphere-sigs/devops-apiserver
     tag: master
   tools:
-    repository: ghcr.io/linuxsuren/devops-tools
+    repository: ghcr.io/kubesphere-sigs/devops-tools
     tag: master
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
- issue: #51 
- Description : 
pointing to container registry **ghcr.io/kubesphere-sigs** instead of **ghcr.io/linuxsuren** in  values.yaml in helm chart
change repository_owner from **kubesphere** to **kubesphere-sigs** in build.yaml
change to docker hub org from **kubespheredev** to **kubespheresig**  in build.yaml