### PR TITLE
Extract authentication jwtSecret as a variable

### DIFF
--- a/charts/ks-devops/templates/config.yaml
+++ b/charts/ks-devops/templates/config.yaml
@@ -6,7 +6,7 @@ data:
       authenticateRateLimiterDuration: 10m0s
       loginHistoryRetentionPeriod: 168h
       maximumClockSkew: 10s
-      jwtSecret: "Z1TBo4jUSB5Rs6eyLqHSJ77GXtG8NhSP"
+      jwtSecret: {{ .Values.authentication.jwtSecret | quote }}
 
     ldap:
       host: openldap.kubesphere-system.svc:389

--- a/charts/ks-devops/templates/deployment-apiserver.yaml
+++ b/charts/ks-devops/templates/deployment-apiserver.yaml
@@ -39,6 +39,8 @@ spec:
             - /jwt
             - --output
             - configmap
+            - --namespace
+            - {{ .Release.Namespace }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
       containers:
         - name: {{ .Chart.Name }}

--- a/charts/ks-devops/values.yaml
+++ b/charts/ks-devops/values.yaml
@@ -13,7 +13,7 @@ image:
   pullPolicy: IfNotPresent
 
 authentication:
-  # Leave
+  # If not set, jwt tools will generate and set it automatically
   jwtSecret: ""
 
 imagePullSecrets: []

--- a/charts/ks-devops/values.yaml
+++ b/charts/ks-devops/values.yaml
@@ -12,6 +12,10 @@ image:
     tag: master
   pullPolicy: IfNotPresent
 
+authentication:
+  # Leave
+  jwtSecret: ""
+
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
### Why we need it

If we hard code authentication jwtSecret in helm charts, the jwt tools in init container of ks-devops-apiserver won't update jwt secret correctly, at least we should set the jwt secret with empty. If we integrate with KubeSphere, consistent secrets are required among ks-devops, ks-devops-plugin and KubeSphere, there is no way to set secret in ks-devops and ks-devops-plugin same as KubeSphere.

### What this PR does:

Extract authentication jwtSecret as a variable. Please refer to #70 for more information.

### Which issue(s) this PR fixes:

Fix #70 

/kind bug