### PR TITLE
Extract agent builder and s2i image's docker registry

### DIFF
--- a/charts/ks-devops/charts/jenkins/README.md
+++ b/charts/ks-devops/charts/jenkins/README.md
@@ -84,17 +84,17 @@ The following tables list the configurable parameters of the Jenkins chart and t
 ### Jenkins Agent
 
 | Parameter                   | Description                                                                                        | Default                                                                      |
-| --------------------------- | -------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
-| `Agent.AlwaysPullImage`     | Always pull agent container image before build                                                     | `false`                                                                      |
-| `Agent.CustomJenkinsLabels` | Append Jenkins labels to the agent                                                                 | `{}`                                                                         |
-| `Agent.Enabled`             | Enable Kubernetes plugin jnlp-agent podTemplate                                                    | `true`                                                                       |
-| `Agent.Image`               | Agent image name                                                                                   | `jenkinsci/jnlp-slave`                                                       |
-| `Agent.ImagePullSecret`     | Agent image pull secret                                                                            | Not set                                                                      |
-| `Agent.ImageTag`            | Agent image tag                                                                                    | `2.62`                                                                       |
-| `Agent.Privileged`          | Agent privileged container                                                                         | `false`                                                                      |
-| `Agent.resources`           | Resources allocation (Requests and Limits)                                                         | `{requests: {cpu: 200m, memory: 256Mi}, limits: {cpu: 200m, memory: 256Mi}}` |
-| `Agent.volumes`             | Additional volumes                                                                                 | `nil`                                                                        |
-| `Agent.Builder.Registry`    | Agent builder image registry with namespace. Like `ghcr.io/kubesphere` or `docker.io/kubesphere` | `docker.io/kubespheredev`
+| --------------------------- | -------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| `Agent.AlwaysPullImage`     | Always pull agent container image before build                                         | `false`                                                                      |
+| `Agent.CustomJenkinsLabels` | Append Jenkins labels to the agent                                                     | `{}`                                                                         |
+| `Agent.Enabled`             | Enable Kubernetes plugin jnlp-agent podTemplate                                        | `true`                                                                       |
+| `Agent.Image`               | Agent image name                                                                       | `jenkinsci/jnlp-slave`                                                       |
+| `Agent.ImagePullSecret`     | Agent image pull secret                                                                | Not set                                                                      |
+| `Agent.ImageTag`            | Agent image tag                                                                        | `2.62`                                                                       |
+| `Agent.Privileged`          | Agent privileged container                                                             | `false`                                                                      |
+| `Agent.resources`           | Resources allocation (Requests and Limits)                                             | `{requests: {cpu: 200m, memory: 256Mi}, limits: {cpu: 200m, memory: 256Mi}}` |
+| `Agent.volumes`             | Additional volumes                                                                     | `nil`                                                                        |
+| `Agent.Builder.Registry`    | Agent builder image registry with namespace. Available values: `docker.io/kubesphere`, `docker.io/kubespheredev`  | `docker.io/kubesphere`                            |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 

--- a/charts/ks-devops/charts/jenkins/README.md
+++ b/charts/ks-devops/charts/jenkins/README.md
@@ -94,7 +94,7 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | `Agent.Privileged`          | Agent privileged container                                                                         | `false`                                                                      |
 | `Agent.resources`           | Resources allocation (Requests and Limits)                                                         | `{requests: {cpu: 200m, memory: 256Mi}, limits: {cpu: 200m, memory: 256Mi}}` |
 | `Agent.volumes`             | Additional volumes                                                                                 | `nil`                                                                        |
-| `Agent.Builder.Registry`    | Agent builder image registry with namespace. Like `ghcr.io/kubesphere` or `[docker.io/]kubesphere` | `kubespheredev`
+| `Agent.Builder.Registry`    | Agent builder image registry with namespace. Like `ghcr.io/kubesphere` or `docker.io/kubesphere` | `docker.io/kubespheredev`
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 

--- a/charts/ks-devops/charts/jenkins/README.md
+++ b/charts/ks-devops/charts/jenkins/README.md
@@ -83,17 +83,18 @@ The following tables list the configurable parameters of the Jenkins chart and t
 
 ### Jenkins Agent
 
-| Parameter                  | Description                                     | Default                |
-| -------------------------- | ----------------------------------------------- | ---------------------- |
-| `Agent.AlwaysPullImage`    | Always pull agent container image before build  | `false`                |
-| `Agent.CustomJenkinsLabels`| Append Jenkins labels to the agent              | `{}`                   |
-| `Agent.Enabled`            | Enable Kubernetes plugin jnlp-agent podTemplate | `true`                 |
-| `Agent.Image`              | Agent image name                                | `jenkinsci/jnlp-slave` |
-| `Agent.ImagePullSecret`    | Agent image pull secret                         | Not set                |
-| `Agent.ImageTag`           | Agent image tag                                 | `2.62`                 |
-| `Agent.Privileged`         | Agent privileged container                      | `false`                |
-| `Agent.resources`          | Resources allocation (Requests and Limits)      | `{requests: {cpu: 200m, memory: 256Mi}, limits: {cpu: 200m, memory: 256Mi}}`|
-| `Agent.volumes`            | Additional volumes                              | `nil`                  |
+| Parameter                   | Description                                                                                        | Default                                                                      |
+| --------------------------- | -------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| `Agent.AlwaysPullImage`     | Always pull agent container image before build                                                     | `false`                                                                      |
+| `Agent.CustomJenkinsLabels` | Append Jenkins labels to the agent                                                                 | `{}`                                                                         |
+| `Agent.Enabled`             | Enable Kubernetes plugin jnlp-agent podTemplate                                                    | `true`                                                                       |
+| `Agent.Image`               | Agent image name                                                                                   | `jenkinsci/jnlp-slave`                                                       |
+| `Agent.ImagePullSecret`     | Agent image pull secret                                                                            | Not set                                                                      |
+| `Agent.ImageTag`            | Agent image tag                                                                                    | `2.62`                                                                       |
+| `Agent.Privileged`          | Agent privileged container                                                                         | `false`                                                                      |
+| `Agent.resources`           | Resources allocation (Requests and Limits)                                                         | `{requests: {cpu: 200m, memory: 256Mi}, limits: {cpu: 200m, memory: 256Mi}}` |
+| `Agent.volumes`             | Additional volumes                                                                                 | `nil`                                                                        |
+| `Agent.Builder.Registry`    | Agent builder image registry with namespace. Like `ghcr.io/kubesphere` or `[docker.io/]kubesphere` | `kubespheredev`
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 

--- a/charts/ks-devops/charts/jenkins/templates/jenkins-casc-config.yml
+++ b/charts/ks-devops/charts/jenkins/templates/jenkins-casc-config.yml
@@ -31,7 +31,7 @@ data:
                 idleMinutes: 0
                 containers:
                 - name: "base"
-                  image: "{{ .Values.Agent.Builder.Base.Image }}:{{ .Values.Agent.Builder.Base.Tag }}"
+                  image: "{{ .Values.Agent.Builder.Registry }}/{{ .Values.Agent.Builder.Base.Image }}:{{ .Values.Agent.Builder.Base.Tag }}"
                   command: "cat"
                   args: ""
                   ttyEnabled: true
@@ -65,7 +65,7 @@ data:
                 idleMinutes: 0
                 containers:
                 - name: "nodejs"
-                  image: "{{ .Values.Agent.Builder.NodeJs.Image }}:{{ .Values.Agent.Builder.NodeJs.Tag }}"
+                  image: "{{ .Values.Agent.Builder.Registry }}/{{ .Values.Agent.Builder.NodeJs.Image }}:{{ .Values.Agent.Builder.NodeJs.Tag }}"
                   command: "cat"
                   args: ""
                   ttyEnabled: true
@@ -105,7 +105,7 @@ data:
                 idleMinutes: 0
                 containers:
                 - name: "maven"
-                  image: "{{ .Values.Agent.Builder.Maven.Image }}:{{ .Values.Agent.Builder.Maven.Tag }}"
+                  image: "{{ .Values.Agent.Builder.Registry }}/{{ .Values.Agent.Builder.Maven.Image }}:{{ .Values.Agent.Builder.Maven.Tag }}"
                   command: "cat"
                   args: ""
                   ttyEnabled: true
@@ -142,7 +142,7 @@ data:
                 idleMinutes: 0
                 containers:
                 - name: "go"
-                  image: "{{ .Values.Agent.Builder.Golang.Image }}:{{ .Values.Agent.Builder.Golang.Tag }}"
+                  image: "{{ .Values.Agent.Builder.Registry }}/{{ .Values.Agent.Builder.Golang.Image }}:{{ .Values.Agent.Builder.Golang.Tag }}"
                   command: "cat"
                   args: ""
                   ttyEnabled: true
@@ -173,7 +173,7 @@ data:
                     mountPath: "/root/.sonar/cache"
                 yaml: "spec:\r\n  affinity:\r\n    nodeAffinity:\r\n      preferredDuringSchedulingIgnoredDuringExecution:\r\n      - weight: 1\r\n        preference:\r\n          matchExpressions:\r\n          - key: node-role.kubernetes.io/worker\r\n            operator: In\r\n            values:\r\n            - ci\r\n  tolerations:\r\n  - key: \"node.kubernetes.io/ci\"\r\n    operator: \"Exists\"\r\n    effect: \"NoSchedule\"\r\n  - key: \"node.kubernetes.io/ci\"\r\n    operator: \"Exists\"\r\n    effect: \"PreferNoSchedule\"\r\n  containers:\r\n  - name: \"go\"\r\n    resources:\r\n      requests:\r\n        ephemeral-storage: \"1Gi\"\r\n      limits:\r\n        ephemeral-storage: \"10Gi\"\r\n  securityContext:\r\n    fsGroup: 1000\r\n "
       securityRealm:
-      {{ if eq .Values.securityRealm.type "ldap" }}
+    {{ if eq .Values.securityRealm.type "ldap" }}
         ldap:
           configurations:
           - displayNameAttributeName: "uid"
@@ -189,9 +189,9 @@ data:
             server: "ldap://{{.Values.securityRealm.ldap.host }}"
           disableMailAddressResolver: false
           disableRolePrefixing: true
-      {{ else }}
+    {{ else }}
       authorizationStrategy: loggedInUsersCanDoAnything
-      {{end}}
+    {{end}}
 
     unclassified:
       location:

--- a/charts/ks-devops/charts/jenkins/values.yaml
+++ b/charts/ks-devops/charts/jenkins/values.yaml
@@ -400,6 +400,7 @@ Agent:
   # jenkins-agent: v1
 
   Builder:
+    # Available values: docker.io/kubesphere, docker.io/kubespheredev
     Registry: "docker.io/kubespheredev"
     Base:
       Image: builder-base

--- a/charts/ks-devops/charts/jenkins/values.yaml
+++ b/charts/ks-devops/charts/jenkins/values.yaml
@@ -400,7 +400,7 @@ Agent:
   # jenkins-agent: v1
 
   Builder:
-    Registry: "kubespheredev"
+    Registry: "docker.io/kubespheredev"
     Base:
       Image: builder-base
       Tag: v3.1.0

--- a/charts/ks-devops/charts/jenkins/values.yaml
+++ b/charts/ks-devops/charts/jenkins/values.yaml
@@ -400,17 +400,18 @@ Agent:
   # jenkins-agent: v1
 
   Builder:
+    Registry: "kubespheredev"
     Base:
-      Image: kubespheredev/builder-base
+      Image: builder-base
       Tag: v3.1.0
     NodeJs:
-      Image: kubespheredev/builder-nodejs
+      Image: builder-nodejs
       Tag: v3.1.0
     Maven:
-      Image: kubespheredev/builder-maven
+      Image: builder-maven
       Tag: v3.1.0
     Golang:
-      Image: kubespheredev/builder-go
+      Image: builder-go
       Tag: v3.1.0
 
 Persistence:

--- a/charts/ks-devops/charts/s2i/README.md
+++ b/charts/ks-devops/charts/s2i/README.md
@@ -1,12 +1,25 @@
 # S2i Helm Charts
 
 - Install s2i charts into Kubernetes
+
 ```shell
 cd charts/ks-devops/charts/s2i
 helm install s2ioperator . -n kubesphere-devops-system --create-namespace
 ```
-- Debug s2i charts locally 
+
+- Debug s2i charts locally
+
 ```shell
 cd charts/ks-devops/charts/s2i
 helm install s2ioperator . --debug --dry-run -n kubesphere-devops-system --create-namespace
 ```
+
+## Configuration
+
+The following tables list the configurable parameters of the s2i chart and their default values.
+
+### s2i image
+
+| Parameter      | Description                                                                                                | Default       |
+| -------------- | ---------------------------------------------------------------------------------------------------------- | ------------- |
+| image.registry | docker image registry related s2i. docker.io/kubespheredev, ghcr.io/kubespheredev or any other registrie | docker.io/kubespheredev |

--- a/charts/ks-devops/charts/s2i/README.md
+++ b/charts/ks-devops/charts/s2i/README.md
@@ -22,4 +22,4 @@ The following tables list the configurable parameters of the s2i chart and their
 
 | Parameter      | Description                                                                                                | Default       |
 | -------------- | ---------------------------------------------------------------------------------------------------------- | ------------- |
-| image.registry | docker image registry related s2i. docker.io/kubespheredev, ghcr.io/kubespheredev or any other registrie | docker.io/kubespheredev |
+| image.registry | docker image registry related s2i. Available value: docker.io/kubespheredev                                | docker.io/kubespheredev |

--- a/charts/ks-devops/charts/s2i/templates/_helpers.tpl
+++ b/charts/ks-devops/charts/s2i/templates/_helpers.tpl
@@ -41,15 +41,3 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
-
-{{/*
-Concrete prefix of s2i image
-*/}}
-{{- define "s2i.imagePrefix" -}}
-{{- if .Values.docker.registry }}
-{{- print .Values.docker.registry "/" .Values.docker.group }}
-{{- else }}
-{{- print .Values.docker.group }}
-{{- end }}
-{{- end }}
-

--- a/charts/ks-devops/charts/s2i/templates/binary.yaml
+++ b/charts/ks-devops/charts/s2i/templates/binary.yaml
@@ -12,7 +12,7 @@ metadata:
   name: binary
 spec:
   containerInfo:
-    - builderImage: {{ template "s2i.imagePrefix" . }}/{{ .Values.binary.image.name }}:{{ .Values.binary.image.tag }}
+    - builderImage: {{ .Values.image.registry }}/{{ .Values.binary.image.name }}:{{ .Values.binary.image.tag }}
   environment:
     - key: ARGS
       type: string
@@ -20,7 +20,7 @@ spec:
       required: false
       defaultValue: ""
   codeFramework: binary
-  defaultBaseImage: {{ template "s2i.imagePrefix" . }}/{{ .Values.binary.image.name }}:{{ .Values.binary.image.tag }}
+  defaultBaseImage: {{ .Values.image.registry }}/{{ .Values.binary.image.name }}:{{ .Values.binary.image.tag }}
   version: 0.0.1
   description: "This is a builder template for binary build"
   iconPath: assets/binary.png

--- a/charts/ks-devops/charts/s2i/templates/java.yaml
+++ b/charts/ks-devops/charts/s2i/templates/java.yaml
@@ -14,13 +14,13 @@ metadata:
   name: java
 spec:
   containerInfo:
-    - builderImage: {{ template "s2i.imagePrefix" . }}/{{ .Values.java8CentOs7.image.name }}:{{ .Values.java8CentOs7.image.tag }}
-      runtimeImage: {{ template "s2i.imagePrefix" . }}/{{ .Values.java8Runtime.image.name }}:{{ .Values.java8Runtime.image.tag }}
+    - builderImage: {{ .Values.image.registry }}/{{ .Values.java8CentOs7.image.name }}:{{ .Values.java8CentOs7.image.tag }}
+      runtimeImage: {{ .Values.image.registry }}/{{ .Values.java8Runtime.image.name }}:{{ .Values.java8Runtime.image.tag }}
       runtimeArtifacts:
         - source: "/deployments"
       buildVolumes: [ "s2i_java_cache:/tmp/artifacts" ]
-    - builderImage: {{ template "s2i.imagePrefix" . }}/{{ .Values.java11CentOs7.image.name }}:{{ .Values.java11CentOs7.image.tag }}
-      runtimeImage: {{ template "s2i.imagePrefix" . }}/{{ .Values.java11Runtime.image.name }}:{{ .Values.java11Runtime.image.tag }}
+    - builderImage: {{ .Values.image.registry }}/{{ .Values.java11CentOs7.image.name }}:{{ .Values.java11CentOs7.image.tag }}
+      runtimeImage: {{ .Values.image.registry }}/{{ .Values.java11Runtime.image.name }}:{{ .Values.java11Runtime.image.tag }}
       runtimeArtifacts:
         - source: "/deployments"
       buildVolumes: [ "s2i_java_cache:/tmp/artifacts" ]
@@ -141,7 +141,7 @@ spec:
       required: false
       defaultValue: ""
   codeFramework: java
-  defaultBaseImage: {{ template "s2i.imagePrefix" . }}/{{ .Values.java8CentOs7.image.name }}:{{ .Values.java8CentOs7.image.tag }}
+  defaultBaseImage: {{ .Values.image.registry }}/{{ .Values.java8CentOs7.image.name }}:{{ .Values.java8CentOs7.image.tag }}
   version: 0.0.1
   description: "This is a builder template for Java builds whose result can be run directly without any further application server.It's suited ideally for microservices with a flat classpath (including \"far jars\")"
   iconPath: assets/java.png

--- a/charts/ks-devops/charts/s2i/templates/nodejs.yaml
+++ b/charts/ks-devops/charts/s2i/templates/nodejs.yaml
@@ -12,9 +12,9 @@ metadata:
   name: nodejs
 spec:
   containerInfo:
-     - builderImage: {{ template "s2i.imagePrefix" . }}/{{ .Values.nodejs8CentOs7.image.name }}:{{ .Values.nodejs8CentOs7.image.tag }}
-     - builderImage: {{ template "s2i.imagePrefix" . }}/{{ .Values.nodejs6CentOs7.image.name }}:{{ .Values.nodejs6CentOs7.image.tag }}
-     - builderImage: {{ template "s2i.imagePrefix" . }}/{{ .Values.nodejs4CentOs7.image.name }}:{{ .Values.nodejs4CentOs7.image.tag }}
+     - builderImage: {{ .Values.image.registry }}/{{ .Values.nodejs8CentOs7.image.name }}:{{ .Values.nodejs8CentOs7.image.tag }}
+     - builderImage: {{ .Values.image.registry }}/{{ .Values.nodejs6CentOs7.image.name }}:{{ .Values.nodejs6CentOs7.image.tag }}
+     - builderImage: {{ .Values.image.registry }}/{{ .Values.nodejs4CentOs7.image.name }}:{{ .Values.nodejs4CentOs7.image.tag }}
   environment:
     - key: NODE_ENV
       type: string
@@ -57,7 +57,7 @@ spec:
       required: false
       defaultValue: ""
   codeFramework: nodejs
-  defaultBaseImage: {{ template "s2i.imagePrefix" . }}/{{ .Values.nodejs8CentOs7.image.name }}:{{ .Values.nodejs8CentOs7.image.tag }}
+  defaultBaseImage: {{ .Values.image.registry }}/{{ .Values.nodejs8CentOs7.image.name }}:{{ .Values.nodejs8CentOs7.image.tag }}
   version: 0.0.1
   description: "Node.js available as container is a base platform for building and running various Node.js applications and frameworks. Node.js is a platform built on Chrome's JavaScript runtime for easily building fast, scalable network applications. Node.js uses an event-driven, non-blocking I/O model that makes it lightweight and efficient, perfect for data-intensive real-time applications that run across distributed devices."
   iconPath: assets/nodejs.png

--- a/charts/ks-devops/charts/s2i/templates/operator.yaml
+++ b/charts/ks-devops/charts/s2i/templates/operator.yaml
@@ -438,8 +438,8 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
             - name: S2IIMAGENAME
-              value: "{{ template "s2i.imagePrefix" . }}/{{ .Values.s2irun.image.name }}:{{ .Values.s2irun.image.tag }}"
-          image: "{{ template "s2i.imagePrefix" . }}/{{ .Values.s2ioperator.image.name }}:{{ .Values.s2ioperator.image.tag }}"
+              value: "{{ .Values.image.registry }}/{{ .Values.s2irun.image.name }}:{{ .Values.s2irun.image.tag }}"
+          image: "{{ .Values.image.registry }}/{{ .Values.s2ioperator.image.name }}:{{ .Values.s2ioperator.image.tag }}"
           imagePullPolicy: IfNotPresent
           name: manager
           ports:

--- a/charts/ks-devops/charts/s2i/templates/python.yaml
+++ b/charts/ks-devops/charts/s2i/templates/python.yaml
@@ -12,10 +12,10 @@ metadata:
     devops.kubesphere.io/s2i-template-url: https://github.com/kubesphere/s2i-python-container
 spec:
   containerInfo:
-    - builderImage: {{ template "s2i.imagePrefix" . }}/{{ .Values.python36CentOs7.image.name }}:{{ .Values.python36CentOs7.image.tag }}
-    - builderImage: {{ template "s2i.imagePrefix" . }}/{{ .Values.python35CentOs7.image.name }}:{{ .Values.python35CentOs7.image.tag }}
-    - builderImage: {{ template "s2i.imagePrefix" . }}/{{ .Values.python34CentOs7.image.name }}:{{ .Values.python34CentOs7.image.tag }}
-    - builderImage: {{ template "s2i.imagePrefix" . }}/{{ .Values.python27CentOs7.image.name }}:{{ .Values.python27CentOs7.image.tag }}
+    - builderImage: {{ .Values.image.registry }}/{{ .Values.python36CentOs7.image.name }}:{{ .Values.python36CentOs7.image.tag }}
+    - builderImage: {{ .Values.image.registry }}/{{ .Values.python35CentOs7.image.name }}:{{ .Values.python35CentOs7.image.tag }}
+    - builderImage: {{ .Values.image.registry }}/{{ .Values.python34CentOs7.image.name }}:{{ .Values.python34CentOs7.image.tag }}
+    - builderImage: {{ .Values.image.registry }}/{{ .Values.python27CentOs7.image.name }}:{{ .Values.python27CentOs7.image.tag }}
   environment:
     - key: APP_SCRIPT
       type: string
@@ -79,7 +79,7 @@ spec:
       defaultValue: ""
       type: string
   codeFramework: python
-  defaultBaseImage: {{ template "s2i.imagePrefix" . }}/{{ .Values.python36CentOs7.image.name }}:{{ .Values.python36CentOs7.image.tag }}
+  defaultBaseImage: {{ .Values.image.registry }}/{{ .Values.python36CentOs7.image.name }}:{{ .Values.python36CentOs7.image.tag }}
   version: 0.0.1
   description: "Python available as container is a base platform for building and running various Python applications and frameworks. Python is an easy to learn, powerful programming language. It has efficient high-level data structures and a simple but effective approach to object-oriented programming. Python's elegant syntax and dynamic typing, together with its interpreted nature, make it an ideal language for scripting and rapid application development in many areas on most platforms.
 

--- a/charts/ks-devops/charts/s2i/templates/tomcat.yaml
+++ b/charts/ks-devops/charts/s2i/templates/tomcat.yaml
@@ -15,13 +15,13 @@ metadata:
 
 spec:
   containerInfo:
-    - builderImage: {{ template "s2i.imagePrefix" . }}/{{ .Values.tomcat85Java11.image.name }}:{{ .Values.tomcat85Java11.image.tag }}
-      runtimeImage: {{ template "s2i.imagePrefix" . }}/{{ .Values.tomcat85Java11Runtime.image.name }}:{{ .Values.tomcat85Java11Runtime.image.tag }}
+    - builderImage: {{ .Values.image.registry }}/{{ .Values.tomcat85Java11.image.name }}:{{ .Values.tomcat85Java11.image.tag }}
+      runtimeImage: {{ .Values.image.registry }}/{{ .Values.tomcat85Java11Runtime.image.name }}:{{ .Values.tomcat85Java11Runtime.image.tag }}
       runtimeArtifacts:
         - source: "/deployments"
       buildVolumes: [ "s2i_java_cache:/tmp/artifacts" ]
-    - builderImage: {{ template "s2i.imagePrefix" . }}/{{ .Values.tomcat85Java8.image.name }}:{{ .Values.tomcat85Java8.image.tag }}
-      runtimeImage: {{ template "s2i.imagePrefix" . }}/{{ .Values.tomcat85Java8Runtime.image.name }}:{{ .Values.tomcat85Java8Runtime.image.tag }}
+    - builderImage: {{ .Values.image.registry }}/{{ .Values.tomcat85Java8.image.name }}:{{ .Values.tomcat85Java8.image.tag }}
+      runtimeImage: {{ .Values.image.registry }}/{{ .Values.tomcat85Java8Runtime.image.name }}:{{ .Values.tomcat85Java8Runtime.image.tag }}
       runtimeArtifacts:
         - source: "/deployments"
       buildVolumes: [ "s2i_java_cache:/tmp/artifacts" ]
@@ -142,7 +142,7 @@ spec:
       required: false
       defaultValue: ""
   codeFramework: java
-  defaultBaseImage: {{ template "s2i.imagePrefix" . }}/{{ .Values.tomcat85Java8.image.name }}:{{ .Values.tomcat85Java8.image.tag }}
+  defaultBaseImage: {{ .Values.image.registry }}/{{ .Values.tomcat85Java8.image.name }}:{{ .Values.tomcat85Java8.image.tag }}
   version: 0.0.1
   description: "This is a builder template for Java builds whose result can be run directly with Tomcat application server."
   iconPath: assets/tomcat.png

--- a/charts/ks-devops/charts/s2i/values.yaml
+++ b/charts/ks-devops/charts/s2i/values.yaml
@@ -2,9 +2,9 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-docker:
-  registry: ""
-  group: "kubespheredev"
+image:
+  # docker.io/kubespheredev, ghcr.io/kubespheredev or any other registries
+  registry: "docker.io/kubespheredev"
 
 # Binary image
 binary:

--- a/charts/ks-devops/charts/s2i/values.yaml
+++ b/charts/ks-devops/charts/s2i/values.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 
 image:
-  # docker.io/kubespheredev, ghcr.io/kubespheredev or any other registries
+  # Available value: docker.io/kubespheredev
   registry: "docker.io/kubespheredev"
 
 # Binary image


### PR DESCRIPTION
### Why we need it

Extracting docker registry as one configuration item lets users configure docker image of ks-devops chart easily. Think about if users want to host a private docker registry for docker images related ks-devops.

### What this PR done

- Extract agent builder docker registry
- Extract s2i builder docker registry

/kind improvment