### PR TITLE
Reload Jenkins CasC in Jenkins Config Controller

### DIFF
--- a/cmd/controller/app/controllers.go
+++ b/cmd/controller/app/controllers.go
@@ -83,8 +83,8 @@ func addControllers(mgr manager.Manager, client k8s.Client, informerFactory info
 			NamespaceInformer: informerFactory.KubernetesSharedInformerFactory().Core().V1().Namespaces(),
 			InformerFactory:   informerFactory,
 
-			ConfigOperator:   devopsClient,
-			ReloadCasCPeriod: s.JenkinsOptions.ReloadCasCPeriod,
+			ConfigOperator:  devopsClient,
+			ReloadCasCDelay: s.JenkinsOptions.ReloadCasCDelay,
 		}, s.JenkinsOptions)
 	}
 

--- a/cmd/controller/app/controllers.go
+++ b/cmd/controller/app/controllers.go
@@ -82,6 +82,8 @@ func addControllers(mgr manager.Manager, client k8s.Client, informerFactory info
 			ConfigMapInformer: informerFactory.KubernetesSharedInformerFactory().Core().V1().ConfigMaps(),
 			NamespaceInformer: informerFactory.KubernetesSharedInformerFactory().Core().V1().Namespaces(),
 			InformerFactory:   informerFactory,
+
+			ConfigOperator: devopsClient,
 		}, s.JenkinsOptions)
 	}
 

--- a/cmd/controller/app/controllers.go
+++ b/cmd/controller/app/controllers.go
@@ -83,7 +83,8 @@ func addControllers(mgr manager.Manager, client k8s.Client, informerFactory info
 			NamespaceInformer: informerFactory.KubernetesSharedInformerFactory().Core().V1().Namespaces(),
 			InformerFactory:   informerFactory,
 
-			ConfigOperator: devopsClient,
+			ConfigOperator:   devopsClient,
+			ReloadCasCPeriod: s.JenkinsOptions.ReloadCasCPeriod,
 		}, s.JenkinsOptions)
 	}
 

--- a/controllers/jenkinsconfig/jenkinsconfig_controller.go
+++ b/controllers/jenkinsconfig/jenkinsconfig_controller.go
@@ -37,7 +37,7 @@ type ControllerOptions struct {
 
 	ConfigOperator devops.ConfigurationOperator
 
-	ReloadCasCPeriod time.Duration
+	ReloadCasCDelay time.Duration
 }
 
 // Controller is used to maintain the state of the jenkins-casc-config ConfigMap.
@@ -54,7 +54,7 @@ type Controller struct {
 
 	queue            workqueue.RateLimitingInterface
 	workerLoopPeriod time.Duration
-	ReloadCasCPeriod time.Duration
+	ReloadCasCDelay  time.Duration
 
 	devopsOptions *jenkins.Options
 }
@@ -77,7 +77,7 @@ func NewController(
 
 		queue:            workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), jenkinsConfigName),
 		workerLoopPeriod: time.Second,
-		ReloadCasCPeriod: options.ReloadCasCPeriod,
+		ReloadCasCDelay:  options.ReloadCasCDelay,
 
 		devopsOptions: devopsOptions,
 	}
@@ -257,8 +257,8 @@ func (c *Controller) syncHandler(key string) error {
 	}
 
 	// Wait some period to reload
-	klog.V(5).Infof("waiting %s to reload Jenkins configuration", c.ReloadCasCPeriod.String())
-	time.Sleep(c.ReloadCasCPeriod)
+	klog.V(5).Infof("waiting %s to reload Jenkins configuration", c.ReloadCasCDelay.String())
+	time.Sleep(c.ReloadCasCDelay)
 
 	// Reload configuration
 	klog.V(5).Info("reloading Jenkins configuration")

--- a/controllers/jenkinsconfig/jenkinsconfig_controller.go
+++ b/controllers/jenkinsconfig/jenkinsconfig_controller.go
@@ -253,12 +253,12 @@ func (c *Controller) syncHandler(key string) error {
 	}
 
 	// Reload configuration
-	klog.V(5).Info("reloading devops configuration")
+	klog.V(5).Info("reloading Jenkins configuration")
 	err = c.configOperator.ReloadConfiguration()
 	if err != nil {
 		return err
 	}
-	klog.V(5).Infof("reloaded devops configuration successfully")
+	klog.V(5).Infof("reloaded Jenkins configuration successfully")
 
 	return nil
 }

--- a/pkg/client/devops/configuration.go
+++ b/pkg/client/devops/configuration.go
@@ -1,0 +1,8 @@
+package devops
+
+// ConfigurationOperator provides APIs for operating devops configuration, like reloading.
+type ConfigurationOperator interface {
+
+	// ReloadConfiguration reload devops configuration
+	ReloadConfiguration() error
+}

--- a/pkg/client/devops/fake/fakedevops.go
+++ b/pkg/client/devops/fake/fakedevops.go
@@ -598,3 +598,7 @@ func (d *Devops) DeleteUserInProject(sid string) error {
 func (d *Devops) GetGlobalRole(roleName string) (string, error) {
 	return "", nil
 }
+
+func (d *Devops) ReloadConfiguration() error {
+	return nil
+}

--- a/pkg/client/devops/interface.go
+++ b/pkg/client/devops/interface.go
@@ -36,6 +36,8 @@ type Interface interface {
 	ProjectOperator
 
 	RoleOperator
+
+	ConfigurationOperator
 }
 
 func GetDevOpsStatusCode(devopsErr error) int {

--- a/pkg/client/devops/jenkins/configuration.go
+++ b/pkg/client/devops/jenkins/configuration.go
@@ -1,0 +1,23 @@
+package jenkins
+
+import (
+	"errors"
+	"net/http"
+)
+
+// According to: https://github.com/jenkinsci/configuration-as-code-plugin/blob/master/docs/features/configurationReload.md
+
+const reloadEndpoint = "/configuration-as-code/reload/"
+
+func (jenkins *Jenkins) ReloadConfiguration() error {
+	// reload Jenkins CasC
+	response, err := jenkins.Requester.Post(reloadEndpoint, nil, nil, nil)
+	if err != nil {
+		return err
+	}
+	if response.StatusCode != http.StatusFound {
+		return errors.New("failed to reload Jenkins CasC")
+	}
+	// reload successfully
+	return nil
+}

--- a/pkg/client/devops/jenkins/devops.go
+++ b/pkg/client/devops/jenkins/devops.go
@@ -15,10 +15,17 @@ package jenkins
 
 import (
 	"kubesphere.io/devops/pkg/client/devops"
+	"net/http"
 )
 
 func NewDevopsClient(options *Options) (devops.Interface, error) {
-	jenkins := CreateJenkins(nil, options.Host, options.MaxConnections, options.Username, options.Password)
+	// we have to create http client with no redirection
+	client := &http.Client{
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+	jenkins := CreateJenkins(client, options.Host, options.MaxConnections, options.Username, options.Password)
 
 	return jenkins, nil
 }

--- a/pkg/client/devops/jenkins/options.go
+++ b/pkg/client/devops/jenkins/options.go
@@ -25,13 +25,13 @@ import (
 )
 
 type Options struct {
-	Host             string        `json:",omitempty" yaml:"host" description:"Jenkins service host address"`
-	Username         string        `json:",omitempty" yaml:"username" description:"Jenkins admin username"`
-	Password         string        `json:",omitempty" yaml:"password" description:"Jenkins admin password"`
-	MaxConnections   int           `json:"maxConnections,omitempty" yaml:"maxConnections" description:"Maximum connections allowed to connect to Jenkins"`
-	Namespace        string        `json:"namespace,omitempty" yaml:"namespace"`
-	WorkerNamespace  string        `json:"workerNamespace,omitempty" yaml:"workerNamespace"`
-	ReloadCasCPeriod time.Duration `json:"reloadCasCPeriod,omitempty" yaml:"reloadCasCPeriod"`
+	Host            string        `json:",omitempty" yaml:"host" description:"Jenkins service host address"`
+	Username        string        `json:",omitempty" yaml:"username" description:"Jenkins admin username"`
+	Password        string        `json:",omitempty" yaml:"password" description:"Jenkins admin password"`
+	MaxConnections  int           `json:"maxConnections,omitempty" yaml:"maxConnections" description:"Maximum connections allowed to connect to Jenkins"`
+	Namespace       string        `json:"namespace,omitempty" yaml:"namespace"`
+	WorkerNamespace string        `json:"workerNamespace,omitempty" yaml:"workerNamespace"`
+	ReloadCasCDelay time.Duration `json:"reloadCasCDelay,omitempty" yaml:"reloadCasCDelay"`
 }
 
 // NewJenkinsOptions returns a `zero` instance
@@ -44,9 +44,9 @@ func NewJenkinsOptions() *Options {
 		Namespace:       "kubesphere-devops-system",
 		WorkerNamespace: "kubesphere-devops-worker",
 		// Default syncFrequency of Kubernetes is "1m", and increasing it will result in longer refresh times for
-		// ConfigMap, so we use 70s as the default value of ReloadCasCPeriod. Please see also:
+		// ConfigMap, so we use 70s as the default value of ReloadCasCDelay. Please see also:
 		// https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/#kubelet-config-k8s-io-v1beta1-KubeletConfiguration
-		ReloadCasCPeriod: 70 * time.Second,
+		ReloadCasCDelay: 70 * time.Second,
 	}
 }
 
@@ -93,7 +93,7 @@ func (s *Options) AddFlags(fs *pflag.FlagSet, c *Options) {
 
 	fs.StringVar(&s.Namespace, "namespace", c.Namespace, "Namespace where devops system is in.")
 	fs.StringVar(&s.WorkerNamespace, "worker-namespace", c.WorkerNamespace, "Namespace where Jenkins agent workers are in.")
-	fs.DurationVar(&s.ReloadCasCPeriod, "reload-casc-period", c.ReloadCasCPeriod,
-		"ReloadCasCPeriod specifies the total duration that controller should delay the reload action for "+
-			"jenkins-casc-config ConfigMap change, and it is only valid for controller manager. Default: \"70s\"")
+	fs.DurationVar(&s.ReloadCasCDelay, "reload-casc-delay", c.ReloadCasCDelay,
+		"ReloadCasCDelay specifies the total duration that controller should delay the reload action for "+
+			"jenkins-casc-config ConfigMap change, and it is only valid for controller manager.")
 }


### PR DESCRIPTION
### Which issue(s) this PR fixes

Fix #73

### Why we need it

Please see #73

### What this PR does

- Add `ConfigurationOperator` in DevOps client
- Reload configuration after reconciling Jenkins agent configuration
- Initial http client with no redirection for Jenkins client

