### PR TITLE
Fix the userInfo is nil

### DIFF
--- a/pkg/kapis/devops/v1alpha2/devops.go
+++ b/pkg/kapis/devops/v1alpha2/devops.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"kubesphere.io/devops/pkg/apiserver/query"
+	"kubesphere.io/devops/pkg/apiserver/request"
 	"net/http"
 	"strings"
 
@@ -323,32 +324,32 @@ func (h *ProjectPipelineHandler) GetPipelineRunNodes(req *restful.Request, resp 
 // only the owner of this Pipeline can approve or reject it
 func (h *ProjectPipelineHandler) approvableCheck(nodes []clientDevOps.NodesDetail, pipe pipelineParam) {
 	var userInfo user.Info
-	//var ok bool
+	var ok bool
 	var isAdmin bool
 	// check if current user belong to the admin group, grant it if it's true
-	//if userInfo, ok = request.UserFrom(pipe.Context); ok {
-	//	createAuth := authorizer.AttributesRecord{
-	//		User:            userInfo,
-	//		Verb:            authorizer.VerbDelete,
-	//		Workspace:       pipe.Workspace,
-	//		DevOps:          pipe.ProjectName,
-	//		Resource:        "devopsprojects",
-	//		ResourceRequest: true,
-	//		ResourceScope:   request.DevOpsScope,
-	//	}
-	//
-	//	if decision, _, err := h.authorizer.Authorize(createAuth); err == nil {
-	//		isAdmin = decision == authorizer.DecisionAllow
-	//	} else {
-	//		// this is an expected case, printing the debug info for troubleshooting
-	//		klog.V(8).Infof("authorize failed with '%v', error is '%v'",
-	//			createAuth, err)
-	//	}
-	//} else {
-	//	klog.V(6).Infof("cannot get the current user when checking the approvable with pipeline '%s/%s'",
-	//		pipe.ProjectName, pipe.Name)
-	//	return
-	//}
+	if userInfo, ok = request.UserFrom(pipe.Context); ok {
+		//createAuth := authorizer.AttributesRecord{
+		//	User:            userInfo,
+		//	Verb:            authorizer.VerbDelete,
+		//	Workspace:       pipe.Workspace,
+		//	DevOps:          pipe.ProjectName,
+		//	Resource:        "devopsprojects",
+		//	ResourceRequest: true,
+		//	ResourceScope:   request.DevOpsScope,
+		//}
+		//
+		//if decision, _, err := h.authorizer.Authorize(createAuth); err == nil {
+		//	isAdmin = decision == authorizer.DecisionAllow
+		//} else {
+		//	// this is an expected case, printing the debug info for troubleshooting
+		//	klog.V(8).Infof("authorize failed with '%v', error is '%v'",
+		//		createAuth, err)
+		//}
+	} else {
+		klog.V(6).Infof("cannot get the current user when checking the approvable with pipeline '%s/%s'",
+			pipe.ProjectName, pipe.Name)
+		return
+	}
 
 	var createdByCurrentUser bool // indicate if the current user is the owner
 	if pipeline, err := h.devopsOperator.GetPipelineObj(pipe.ProjectName, pipe.Name); err == nil {


### PR DESCRIPTION
I got a nil error when trying to access the Pipeline log output page:

```
2021/07/26 06:13:19 http: panic serving 10.233.115.47:41822: runtime error: invalid memory address or nil pointer dereference
goroutine 892 [running]:
net/http.(*conn).serve.func1(0xc000ae3180)
	/usr/local/go/src/net/http/server.go:1795 +0x139
panic(0x1c06000, 0x333f2f0)
	/usr/local/go/src/runtime/panic.go:679 +0x1b2
kubesphere.io/devops/pkg/kapis/devops/v1alpha2.(*ProjectPipelineHandler).approvableCheck(0xc000a7c180, 0x3388910, 0x0, 0x0, 0x0, 0x0, 0xc0019cb530, 0x9, 0xc0019cb544, 0x4, ...)
	/workspace/pkg/kapis/devops/v1alpha2/devops.go:356 +0xf2
kubesphere.io/devops/pkg/kapis/devops/v1alpha2.(*ProjectPipelineHandler).GetNodesDetail(0xc000a7c180, 0xc001561b60, 0xc00039b810)
	/workspace/pkg/kapis/devops/v1alpha2/devops.go:480 +0x407
github.com/emicklei/go-restful.(*FilterChain).ProcessFilter(0xc001561bf0, 0xc001561b60, 0xc00039b810)
	/go/pkg/mod/github.com/emicklei/go-restful@v2.9.6+incompatible/filter.go:21 +0x8b
kubesphere.io/devops/pkg/apiserver.logRequestAndResponse(0xc001561b60, 0xc00039b810, 0xc001561bf0)
	/workspace/pkg/apiserver/apiserver.go:341 +0x82
github.com/emicklei/go-restful.(*FilterChain).ProcessFilter(0xc001561bf0, 0xc001561b60, 0xc00039b810)
	/go/pkg/mod/github.com/emicklei/go-restful@v2.9.6+incompatible/filter.go:19 +0x65
```

For now, I prefer to make sure the API works. And fix the auth problem later.