### PR TITLE
Add prometheus service monitor and rule

### DIFF
--- a/charts/ks-devops/charts/jenkins/README.md
+++ b/charts/ks-devops/charts/jenkins/README.md
@@ -26,75 +26,87 @@ $ helm install --name my-release stable/jenkins
 The following tables list the configurable parameters of the Jenkins chart and their default values.
 
 ### Jenkins Master
-| Parameter                         | Description                          | Default                                                                      |
-| --------------------------------- | ------------------------------------ | ---------------------------------------------------------------------------- |
-| `nameOverride`                    | Override the resource name prefix    | `jenkins`                                                                    |
-| `fullnameOverride`                | Override the full resource names     | `jenkins-{release-name}` (or `jenkins` if release-name is `jenkins`)         |
-| `Master.Name`                     | Jenkins master name                  | `jenkins-master`                                                             |
-| `Master.Image`                    | Master image name                    | `jenkinsci/jenkins`                                                          |
-| `Master.ImageTag`                 | Master image tag                     | `lts`                                                                     |
-| `Master.ImagePullPolicy`          | Master image pull policy             | `Always`                                                                     |
-| `Master.ImagePullSecret`          | Master image pull secret             | Not set                                                                      |
-| `Master.Component`                | k8s selector key                     | `jenkins-master`                                                             |
-| `Master.UseSecurity`              | Use basic security                   | `true`                                                                       |
-| `Master.AdminUser`                | Admin username (and password) created as a secret if useSecurity is true | `admin`                                  |
-| `Master.AdminPassword`            | Admin password (and user) created as a secret if useSecurity is true | Random value                                  |
-| `Master.JenkinsAdminEmail`        | Email address for the administrator of the Jenkins instance | Not set                                               |
-| `Master.resources`                | Resources allocation (Requests and Limits) | `{requests: {cpu: 50m, memory: 256Mi}, limits: {cpu: 2000m, memory: 2048Mi}}`|
-| `Master.InitContainerEnv`         | Environment variables for Init Container                                 | Not set                                  |
-| `Master.ContainerEnv`             | Environment variables for Jenkins Container                              | Not set                                  |
-| `Master.UsePodSecurityContext`    | Enable pod security context (must be `true` if `RunAsUser` or `FsGroup` are set) | `true`                           |
-| `Master.RunAsUser`                | uid that jenkins runs with           | `0`                                                                          |
-| `Master.FsGroup`                  | uid that will be used for persistent volume | `0`                                                                   |
-| `Master.ServiceAnnotations`       | Service annotations                  | `{}`                                                                         |
-| `Master.ServiceType`              | k8s service type                     | `LoadBalancer`                                                               |
-| `Master.ServicePort`              | k8s service port                     | `8080`                                                                       |
-| `Master.NodePort`                 | k8s node port                        | Not set                                                                      |
-| `Master.HealthProbes`             | Enable k8s liveness and readiness probes | `true`                                                                   |
-| `Master.HealthProbesLivenessTimeout`      | Set the timeout for the liveness probe | `120`                                                       |
-| `Master.HealthProbesReadinessTimeout` | Set the timeout for the readiness probe | `60`                                                       |
-| `Master.HealthProbeLivenessFailureThreshold` | Set the failure threshold for the liveness probe | `12`                                                       |
-| `Master.SlaveListenerPort`        | Listening port for agents            | `50000`                                                                      |
-| `Master.DisabledAgentProtocols`   | Disabled agent protocols             | `JNLP-connect JNLP2-connect`                                                                      |
-| `Master.CSRF.DefaultCrumbIssuer.Enabled` | Enable the default CSRF Crumb issuer | `true`                                                                      |
-| `Master.CSRF.DefaultCrumbIssuer.ProxyCompatability` | Enable proxy compatibility | `true`                                                                      |
-| `Master.CLI`                      | Enable CLI over remoting             | `false`                                                                      |
-| `Master.LoadBalancerSourceRanges` | Allowed inbound IP addresses         | `0.0.0.0/0`                                                                  |
-| `Master.LoadBalancerIP`           | Optional fixed external IP           | Not set                                                                      |
-| `Master.JMXPort`                  | Open a port, for JMX stats           | Not set                                                                      |
-| `Master.CustomConfigMap`          | Use a custom ConfigMap               | `false`                                                                      |
-| `Master.OverwriteConfig`          | Replace config w/ ConfigMap on boot  | `false`                                                                      |
-| `Master.Ingress.Annotations`      | Ingress annotations                  | `{}`                                                                         |
-| `Master.Ingress.TLS`              | Ingress TLS configuration            | `[]`                                                                         |
-| `Master.InitScripts`              | List of Jenkins init scripts         | Not set                                                                      |
-| `Master.CredentialsXmlSecret`     | Kubernetes secret that contains a 'credentials.xml' file | Not set                                                  |
-| `Master.SecretsFilesSecret`       | Kubernetes secret that contains 'secrets' files | Not set                                                           |
-| `Master.Jobs`                     | Jenkins XML job configs              | Not set                                                                      |
-| `Master.ScriptApproval`           | List of groovy functions to approve  | Not set                                                                      |
-| `Master.NodeSelector`             | Node labels for pod assignment       | `{}`                                                                         |
-| `Master.Affinity`                 | Affinity settings                    | `{}`                                                                         |
-| `Master.Tolerations`              | Toleration labels for pod assignment | `{}`                                                                         |
-| `Master.PodAnnotations`           | Annotations for master pod           | `{}`                                                                         |
-| `NetworkPolicy.Enabled`           | Enable creation of NetworkPolicy resources. | `false`                                                               |
-| `NetworkPolicy.ApiVersion`        | NetworkPolicy ApiVersion             | `networking.k8s.io/v1beta1`                                                         |
-| `rbac.install`                    | Create service account and ClusterRoleBinding for Kubernetes plugin | `false`                                       |
-| `rbac.roleRef`                    | Cluster role name to bind to         | `cluster-admin`                                                              |
-| `rbac.roleBindingKind`            | Role kind (`RoleBinding` or `ClusterRoleBinding`)| `ClusterRoleBinding`                                             |
+| Parameter                                           | Description                                                                      | Default                                                                       |
+| ---                                                 | ---                                                                              | ---                                                                           |
+| `nameOverride`                                      | Override the resource name prefix                                                | `jenkins`                                                                     |
+| `fullnameOverride`                                  | Override the full resource names                                                 | `jenkins-{release-name}` (or `jenkins` if release-name is `jenkins`)          |
+| `Master.Name`                                       | Jenkins master name                                                              | `jenkins-master`                                                              |
+| `Master.Image`                                      | Master image name                                                                | `jenkinsci/jenkins`                                                           |
+| `Master.ImageTag`                                   | Master image tag                                                                 | `lts`                                                                         |
+| `Master.ImagePullPolicy`                            | Master image pull policy                                                         | `Always`                                                                      |
+| `Master.ImagePullSecret`                            | Master image pull secret                                                         | Not set                                                                       |
+| `Master.Component`                                  | k8s selector key                                                                 | `jenkins-master`                                                              |
+| `Master.UseSecurity`                                | Use basic security                                                               | `true`                                                                        |
+| `Master.AdminUser`                                  | Admin username (and password) created as a secret if useSecurity is true         | `admin`                                                                       |
+| `Master.AdminPassword`                              | Admin password (and user) created as a secret if useSecurity is true             | Random value                                                                  |
+| `Master.JenkinsAdminEmail`                          | Email address for the administrator of the Jenkins instance                      | Not set                                                                       |
+| `Master.resources`                                  | Resources allocation (Requests and Limits)                                       | `{requests: {cpu: 50m, memory: 256Mi}, limits: {cpu: 2000m, memory: 2048Mi}}` |
+| `Master.InitContainerEnv`                           | Environment variables for Init Container                                         | Not set                                                                       |
+| `Master.ContainerEnv`                               | Environment variables for Jenkins Container                                      | Not set                                                                       |
+| `Master.UsePodSecurityContext`                      | Enable pod security context (must be `true` if `RunAsUser` or `FsGroup` are set) | `true`                                                                        |
+| `Master.RunAsUser`                                  | uid that jenkins runs with                                                       | `0`                                                                           |
+| `Master.FsGroup`                                    | uid that will be used for persistent volume                                      | `0`                                                                           |
+| `Master.ServiceAnnotations`                         | Service annotations                                                              | `{}`                                                                          |
+| `Master.ServiceType`                                | k8s service type                                                                 | `LoadBalancer`                                                                |
+| `Master.ServicePort`                                | k8s service port                                                                 | `8080`                                                                        |
+| `Master.NodePort`                                   | k8s node port                                                                    | Not set                                                                       |
+| `Master.HealthProbes`                               | Enable k8s liveness and readiness probes                                         | `true`                                                                        |
+| `Master.HealthProbesLivenessTimeout`                | Set the timeout for the liveness probe                                           | `120`                                                                         |
+| `Master.HealthProbesReadinessTimeout`               | Set the timeout for the readiness probe                                          | `60`                                                                          |
+| `Master.HealthProbeLivenessFailureThreshold`        | Set the failure threshold for the liveness probe                                 | `12`                                                                          |
+| `Master.SlaveListenerPort`                          | Listening port for agents                                                        | `50000`                                                                       |
+| `Master.DisabledAgentProtocols`                     | Disabled agent protocols                                                         | `JNLP-connect JNLP2-connect`                                                  |
+| `Master.CSRF.DefaultCrumbIssuer.Enabled`            | Enable the default CSRF Crumb issuer                                             | `true`                                                                        |
+| `Master.CSRF.DefaultCrumbIssuer.ProxyCompatability` | Enable proxy compatibility                                                       | `true`                                                                        |
+| `Master.CLI`                                        | Enable CLI over remoting                                                         | `false`                                                                       |
+| `Master.LoadBalancerSourceRanges`                   | Allowed inbound IP addresses                                                     | `0.0.0.0/0`                                                                   |
+| `Master.LoadBalancerIP`                             | Optional fixed external IP                                                       | Not set                                                                       |
+| `Master.JMXPort`                                    | Open a port, for JMX stats                                                       | Not set                                                                       |
+| `Master.CustomConfigMap`                            | Use a custom ConfigMap                                                           | `false`                                                                       |
+| `Master.OverwriteConfig`                            | Replace config w/ ConfigMap on boot                                              | `false`                                                                       |
+| `Master.Ingress.Annotations`                        | Ingress annotations                                                              | `{}`                                                                          |
+| `Master.Ingress.TLS`                                | Ingress TLS configuration                                                        | `[]`                                                                          |
+| `Master.InitScripts`                                | List of Jenkins init scripts                                                     | Not set                                                                       |
+| `Master.CredentialsXmlSecret`                       | Kubernetes secret that contains a 'credentials.xml' file                         | Not set                                                                       |
+| `Master.SecretsFilesSecret`                         | Kubernetes secret that contains 'secrets' files                                  | Not set                                                                       |
+| `Master.Jobs`                                       | Jenkins XML job configs                                                          | Not set                                                                       |
+| `Master.ScriptApproval`                             | List of groovy functions to approve                                              | Not set                                                                       |
+| `Master.NodeSelector`                               | Node labels for pod assignment                                                   | `{}`                                                                          |
+| `Master.Affinity`                                   | Affinity settings                                                                | `{}`                                                                          |
+| `Master.Tolerations`                                | Toleration labels for pod assignment                                             | `{}`                                                                          |
+| `Master.PodAnnotations`                             | Annotations for master pod                                                       | `{}`                                                                          |
+| `NetworkPolicy.Enabled`                             | Enable creation of NetworkPolicy resources.                                      | `false`                                                                       |
+| `NetworkPolicy.ApiVersion`                          | NetworkPolicy ApiVersion                                                         | `networking.k8s.io/v1beta1`                                                   |
+| `rbac.install`                                      | Create service account and ClusterRoleBinding for Kubernetes plugin              | `false`                                                                       |
+| `rbac.roleRef`                                      | Cluster role name to bind to                                                     | `cluster-admin`                                                               |
+| `rbac.roleBindingKind`                              | Role kind (`RoleBinding` or `ClusterRoleBinding`)                                | `ClusterRoleBinding`                                                          |
 
 ### Jenkins Agent
 
-| Parameter                   | Description                                                                                        | Default                                                                      |
-| --------------------------- | -------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
-| `Agent.AlwaysPullImage`     | Always pull agent container image before build                                         | `false`                                                                      |
-| `Agent.CustomJenkinsLabels` | Append Jenkins labels to the agent                                                     | `{}`                                                                         |
-| `Agent.Enabled`             | Enable Kubernetes plugin jnlp-agent podTemplate                                        | `true`                                                                       |
-| `Agent.Image`               | Agent image name                                                                       | `jenkinsci/jnlp-slave`                                                       |
-| `Agent.ImagePullSecret`     | Agent image pull secret                                                                | Not set                                                                      |
-| `Agent.ImageTag`            | Agent image tag                                                                        | `2.62`                                                                       |
-| `Agent.Privileged`          | Agent privileged container                                                             | `false`                                                                      |
-| `Agent.resources`           | Resources allocation (Requests and Limits)                                             | `{requests: {cpu: 200m, memory: 256Mi}, limits: {cpu: 200m, memory: 256Mi}}` |
-| `Agent.volumes`             | Additional volumes                                                                     | `nil`                                                                        |
-| `Agent.Builder.Registry`    | Agent builder image registry with namespace. Available values: `docker.io/kubesphere`, `docker.io/kubespheredev`  | `docker.io/kubesphere`                            |
+| Parameter                   | Description                                                                                                      | Default                                                                      |
+| ---                         | ---                                                                                                              | ---                                                                          |
+| `Agent.AlwaysPullImage`     | Always pull agent container image before build                                                                   | `false`                                                                      |
+| `Agent.CustomJenkinsLabels` | Append Jenkins labels to the agent                                                                               | `{}`                                                                         |
+| `Agent.Enabled`             | Enable Kubernetes plugin jnlp-agent podTemplate                                                                  | `true`                                                                       |
+| `Agent.Image`               | Agent image name                                                                                                 | `jenkinsci/jnlp-slave`                                                       |
+| `Agent.ImagePullSecret`     | Agent image pull secret                                                                                          | Not set                                                                      |
+| `Agent.ImageTag`            | Agent image tag                                                                                                  | `2.62`                                                                       |
+| `Agent.Privileged`          | Agent privileged container                                                                                       | `false`                                                                      |
+| `Agent.resources`           | Resources allocation (Requests and Limits)                                                                       | `{requests: {cpu: 200m, memory: 256Mi}, limits: {cpu: 200m, memory: 256Mi}}` |
+| `Agent.volumes`             | Additional volumes                                                                                               | `nil`                                                                        |
+| `Agent.Builder.Registry`    | Agent builder image registry with namespace. Available values: `docker.io/kubesphere`, `docker.io/kubespheredev` | `docker.io/kubesphere`                                                       |
+
+### Prometheus monitor
+
+| Parameter                              | Description                                     | Default                                                                                              |
+| ---                                    | ---                                             | ---                                                                                                  |
+| `prometheus.namespace`                 | Namespace of Prometheus resources               | `""`                                                                                                 |
+| `prometheus.serviceMonitor.disabled`   | Disable prometheus service monitor              | `false`                                                                                              |
+| `prometheus.serviceMonitor.labels`     | Labels of prometheus service monitor            | `{}`                                                                                                 |
+| `prometheus.prometheusRule.disabled`   | Disable prometheus rule                         | `false`                                                                                              |
+| `prometheus.prometheusRule.lables`     | Add these labels to metadata of prometheus rule | `{"custom-alerting-rule-level":"cluster","role":"thanos-alerting-rules","thanosruler":"thanos-rul"}` |
+| `prometheus.prometheusRule.alertRules` | Append these alert rules to prometheus rule     | `[]`                                                                                                 |
+
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 
@@ -146,7 +158,7 @@ It is possible to mount several volumes using `Persistence.volumes` and `Persist
 ### Persistence Values
 
 | Parameter                   | Description                     | Default         |
-| --------------------------- | ------------------------------- | --------------- |
+| ---                         | ---                             | ---             |
 | `Persistence.Enabled`       | Enable the use of a Jenkins PVC | `true`          |
 | `Persistence.ExistingClaim` | Provide the name of a PVC       | `nil`           |
 | `Persistence.AccessMode`    | The PVC access mode             | `ReadWriteOnce` |

--- a/charts/ks-devops/charts/jenkins/templates/prometheus-prometheusrule.yaml
+++ b/charts/ks-devops/charts/jenkins/templates/prometheus-prometheusrule.yaml
@@ -1,0 +1,53 @@
+{{ if and (not .Values.prometheus.prometheusRule.disabled) (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1/PrometheusRule") }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  {{- with .Values.prometheus.prometheusRule.labels }}
+  labels:
+  {{- toYaml . | nindent 4}}
+  {{- end }}
+  name: {{ template "jenkins.fullname" . }}-rules
+  namespace: {{ .Values.prometheus.namespace | default "default"}}
+spec:
+  groups:
+    - name: {{ template "jenkins.fullname" . }}.jenkins.rules
+      rules:
+        - alert: jenkins-cpu-overcommit
+          annotations:
+            summary: {{`Jenkins({{ $labels.instance }}) process has overcommitted CPU resource requests.`}}
+          expr: >
+            sum(rate(process_cpu_seconds_total{container="{{ template "jenkins.fullname" . }}", namespace="{{ .Release.Namespace }}"}[5m])) by (container, instance) > 0.8
+          for: 5m
+          labels:
+            alerttype: metric
+            severity: warning
+        - alert: jenkins-down
+          annotations:
+            message: Jenkins has disppeared from Prometheus target discovery.
+          expr: absent(default_jenkins_up)
+          for: 5m
+          labels:
+            alerttype: metric
+            severity: critical
+        - alert: jenkins-too-many-stuck-jobs
+          annotations:
+            summary: Jenkins has too many stuck jobs.
+            message: {{`Jenkins has more than 10 stuck jobs({{ $value | humanize }}) in the past 5 minutes. Please have an inspection about jenkins.`}}
+          expr: avg_over_time(jenkins_queue_size_value[5m]) > 10
+          for: 5m
+          labels:
+            alerttype: metric
+            severity: warning
+        - alert: jenkins-too-many-failure-jobs
+          annotations:
+            summary: Jenkins has too many failed jobs.
+            message: {{`Jenkins has more than 5 failed jobs({{ $value | humanize }}) in the past 5 minutes.`}}
+          expr: increase(jenkins_runs_failure_total{namespace='{{ .Release.Namespace }}', container='{{ template "jenkins.fullname" . }}', job='{{ template "jenkins.fullname" }}'}[5m]) > 5
+          for: 5m
+          labels:
+            alerttype: metric
+            severity: warning
+  {{- with .Values.prometheus.prometheusRule.alertRules }}
+  {{- toYaml . | nindent 8 }}
+  {{- end }}
+  {{ end -}}

--- a/charts/ks-devops/charts/jenkins/templates/prometheus-servicemonitor.yaml
+++ b/charts/ks-devops/charts/jenkins/templates/prometheus-servicemonitor.yaml
@@ -1,0 +1,24 @@
+{{ if and (not .Values.prometheus.serviceMonitor.disabled) (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1/ServiceMonitor") -}}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  {{- with .Values.prometheus.serviceMonitor.labels }}
+  labels:
+  {{- toYaml . | nindent 4}}
+  {{- end}}
+  name: {{ template "jenkins.fullname" . }}
+  namespace: {{ .Values.prometheus.namespace | default "default" }}
+spec:
+  endpoints:
+    - honorLabels: true
+      interval: 1m
+      port: http
+      path: /prometheus/
+  jobLabel: {{ template "jenkins.fullname" .}}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      app: {{ template "jenkins.fullname" . }}
+  {{ end -}}

--- a/charts/ks-devops/charts/jenkins/values.yaml
+++ b/charts/ks-devops/charts/jenkins/values.yaml
@@ -463,3 +463,17 @@ securityRealm:
 ksAuth:
   enabled: false
 #  server:
+
+# Install service monitor
+prometheus:
+  namespace: ""
+  serviceMonitor:
+    disabled: false
+    labels: { }
+  prometheusRule:
+    disabled: false
+    labels:
+      custom-alerting-rule-level: cluster
+      role: thanos-alerting-rules
+      thanosruler: thanos-rule
+    alertRules: [ ]

--- a/charts/ks-devops/charts/s2i/README.md
+++ b/charts/ks-devops/charts/s2i/README.md
@@ -20,6 +20,14 @@ The following tables list the configurable parameters of the s2i chart and their
 
 ### s2i image
 
-| Parameter      | Description                                                                                                | Default       |
-| -------------- | ---------------------------------------------------------------------------------------------------------- | ------------- |
-| image.registry | docker image registry related s2i. Available value: docker.io/kubespheredev                                | docker.io/kubespheredev |
+| Parameter      | Description                                                                 | Default                 |
+| ---            | ---                                                                         | ---                     |
+| image.registry | docker image registry related s2i. Available value: docker.io/kubespheredev | docker.io/kubespheredev |
+
+### Prometheus
+
+| Parameter                            | Description                                          | Default |
+| ---                                  | ---                                                  | ---     |
+| `prometheus.namespace`               | Namespace of prometheus resources                    | `""`    |
+| `prometheus.serviceMonitor.disabled` | Disable prometheus service monitor                   | `true`  |
+| `prometheus.serviceMonitor.labels`   | Add labels to metadata of prometheus service monitor | `{}`    |

--- a/charts/ks-devops/charts/s2i/templates/prometheus-servicemonitor.yaml
+++ b/charts/ks-devops/charts/s2i/templates/prometheus-servicemonitor.yaml
@@ -1,0 +1,28 @@
+{{ if and (not .Values.prometheus.serviceMonitor.disabled) (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1/ServiceMonitor") -}}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  {{- with .Values.prometheus.serviceMonitor.labels }}
+  labels:
+  {{- toYaml . | nindent 4}}
+  {{- end }}
+  name: s2i-operator
+  namespace: {{ .Values.prometheus.namespace | default "default"}}
+spec:
+  endpoints:
+    - honorLabels: true
+      interval: 1m
+      metricRelabelings:
+        - action: keep
+          regex: s2i_s2ibuilder_created
+          sourceLabels:
+            - __name__
+      port: http
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      app: s2i-metrics
+      control-plane: s2i-controller-manager
+  {{ end -}}

--- a/charts/ks-devops/charts/s2i/values.yaml
+++ b/charts/ks-devops/charts/s2i/values.yaml
@@ -182,3 +182,9 @@ s2ioperator:
       p2hvkjDixDbGS3Svi45eEpBnIrcma+fanPKJCYUZbiRIoD+kA8Ss5mZgtah3LcrQ
       U8UUR60N6LJ52m2ik/zHh+p31ihhCz7F7JWq7itNpbjFcb9T6g==
       -----END CERTIFICATE-----
+
+prometheus:
+  namespace: ""
+  serviceMonitor:
+    disabled: false
+    labels: { }


### PR DESCRIPTION
### Why we need it

This PR aims to make users use ks-devops metrics out of box or integrate with Prometheus easily.

### What this PR dose

- Add Prometheus ServiceMonitor and PrometheusRule in Jenkins helm chart
- Add Prometheus ServiceMonitor in S2I helm chart

/kind feature