### PR TITLE
Fix ks-devops-apiserver crash while viewing parallel pipeline activity detail

### DIFF
--- a/pkg/models/devops/devops.go
+++ b/pkg/models/devops/devops.go
@@ -541,7 +541,8 @@ func (d devopsOperator) GetNodesDetail(projectName, pipelineName, runId string, 
 	for i, v := range respNodes {
 		wg.Add(1)
 		go func(nodeId string, index int) {
-			Steps, err := d.GetNodeSteps(projectName, pipelineName, runId, nodeId, req)
+			// We have to clone the request to prevent concurrent header writes in the next process
+			Steps, err := d.GetNodeSteps(projectName, pipelineName, runId, nodeId, req.Clone(context.TODO()))
 			if err != nil {
 				klog.Error(err)
 				return


### PR DESCRIPTION
### What this PR dose

Clone request in `convertToHttpParameters` method.

### Why we need it

Before this, `ks-devops-apiserver` may crash while we view parallel pipeline activity detail. The detailed error stack is showed below:

```go
fatal error: concurrent map writes

goroutine 12555 [running]:
runtime.throw(0x1ee0045, 0x15)
	/usr/local/go/src/runtime/panic.go:774 +0x72 fp=0xc000e6d9d8 sp=0xc000e6d9a8 pc=0x42e542
runtime.mapassign_faststr(0x1cde0e0, 0xc000ba2600, 0x1ed12ad, 0xd, 0x1)
	/usr/local/go/src/runtime/map_faststr.go:291 +0x3fe fp=0xc000e6da40 sp=0xc000e6d9d8 pc=0x41301e
net/textproto.MIMEHeader.Set(...)
	/usr/local/go/src/net/textproto/header.go:22
net/http.Header.Set(...)
	/usr/local/go/src/net/http/header.go:37
kubesphere.io/devops/pkg/client/devops/jenkins.(*Jenkins).SendPureRequestWithHeaderResp(0xc00024e990, 0xc0014fc000, 0x7a, 0xc00180b100, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0)
	/workspace/pkg/client/devops/jenkins/pure_request.go:56 +0x89e fp=0xc000e6dbf0 sp=0xc000e6da40 pc=0x18da0ae
kubesphere.io/devops/pkg/client/devops/jenkins.(*Jenkins).SendPureRequest(...)
	/workspace/pkg/client/devops/jenkins/pure_request.go:33
kubesphere.io/devops/pkg/client/devops/jenkins.(*Pipeline).GetNodeSteps(0xc000e6dcf0, 0x5e, 0xc000e6dd10, 0x4, 0x4, 0xc0014fc000)
	/workspace/pkg/client/devops/jenkins/pipeline.go:369 +0x5e fp=0xc000e6dca0 sp=0xc000e6dbf0 pc=0x18cc4de
kubesphere.io/devops/pkg/client/devops/jenkins.(*Jenkins).GetNodeSteps(0xc00024e990, 0xc000d66300, 0x16, 0xc000d66321, 0xb, 0xc000d66332, 0x2, 0x32ead59, 0x1, 0xc00180b100, ...)
	/workspace/pkg/client/devops/jenkins/jenkins.go:579 +0x1f7 fp=0xc000e6dd60 sp=0xc000e6dca0 pc=0x18c2207
kubesphere.io/devops/pkg/models/devops.devopsOperator.GetNodeSteps(0x23ef480, 0xc00024e990, 0x23e73a0, 0xc00061a2c0, 0x23930a0, 0xc000344700, 0x239be20, 0xc0000bc020, 0xc000d66300, 0x16, ...)
	/workspace/pkg/models/devops/devops.go:486 +0x1b3 fp=0xc000e6de50 sp=0xc000e6dd60 pc=0x1990db3
kubesphere.io/devops/pkg/models/devops.devopsOperator.GetNodesDetail.func1(0x23ef480, 0xc00024e990, 0x23e73a0, 0xc00061a2c0, 0x23930a0, 0xc000344700, 0x239be20, 0xc0000bc020, 0xc000d66300, 0x16, ...)
	/workspace/pkg/models/devops/devops.go:544 +0xdf fp=0xc000e6df40 sp=0xc000e6de50 pc=0x199c2bf
runtime.goexit()
	/usr/local/go/src/runtime/asm_amd64.s:1357 +0x1 fp=0xc000e6df48 sp=0xc000e6df40 pc=0x45b711
created by kubesphere.io/devops/pkg/models/devops.devopsOperator.GetNodesDetail
	/workspace/pkg/models/devops/devops.go:543 +0x466
```

Meanwhile, `pkg/models/devops/devops.go#GetNodesDetail` method may call  `pkg/models/devops/devops.go#GetNodeSteps` concurrently.

https://github.com/kubesphere-sigs/ks-devops/blob/5a7d050f52217be2251c1ffe377f0adb76c0c3c1/pkg/models/devops/devops.go#L540-L556

And the callee will call `pkg/models/devops/devops.go#convertToHttpParameters` method.

https://github.com/kubesphere-sigs/ks-devops/blob/5a7d050f52217be2251c1ffe377f0adb76c0c3c1/pkg/models/devops/devops.go#L485-L493

Please note that, the return `HttpParameters` of `convertToHttpParameters` method will share some data, like header(map[string][]string), with `http.request` parameter.

https://github.com/kubesphere-sigs/ks-devops/blob/5a7d050f52217be2251c1ffe377f0adb76c0c3c1/pkg/models/devops/devops.go#L139-L150

But if some places try to modify the share data as I mentioned above, `fatal error: concurrent map writes` will occur. Please see line 56.

https://github.com/kubesphere-sigs/ks-devops/blob/5a7d050f52217be2251c1ffe377f0adb76c0c3c1/pkg/client/devops/jenkins/pure_request.go#L38-L61

### Which issue dose this PR fix

Fix #87 

###  Step to test

Please replace docker image `johnniang/ks-devops-apiserver:concurrent-map-write-bug` of `ks-devops-apiserver` deployment, and re-do [this](https://github.com/kubesphere-sigs/ks-devops/issues/87#issuecomment-891550514).

/kind bug